### PR TITLE
Fix edge coloring so that sequential numbering is not required

### DIFF
--- a/icepack/plot.py
+++ b/icepack/plot.py
@@ -57,14 +57,14 @@ def plot_mesh(mesh, colors=None, axes=None, **kwargs):
     markers = facets.unique_markers
     clrs = _get_colors(colors, len(markers))
 
-    for marker in markers:
+    for i, marker in enumerate(markers):
         indices = facets.subset(int(marker)).indices
         n = len(indices)
         roll = 2 - local_facet_id[indices]
         cell = coordinates.exterior_facet_node_map().values[indices, :]
         edges = np.array([np.roll(cell[k,:], roll[k]) for k in range(n)])[:,:2]
         vertices = coords[edges]
-        lines = LineCollection(vertices, color=clrs[marker-1], label=marker,
+        lines = LineCollection(vertices, color=clrs[i], label=marker,
                                **kwargs)
         axes.add_collection(lines)
     axes.legend()


### PR DESCRIPTION
I was getting an index error on plotting the mesh, resulting from an implicit requirement in the plotting code that edges are numbered sequentially starting at 1. I don't generally number edges sequentially in gmsh, and it seems that gmsh and the rest of icepack don't require it, so I changed the mesh plotting to color the edges without requiring a certain numbering.