### PR TITLE
Icepack install tweaks

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -17,7 +17,7 @@ Quick start
 
 * Run the icepack unit tests to make sure everything's working::
 
-   cd firedrake/src/icepack
+   cd $VIRTUAL_ENV/src/icepack
    pytest -s
 
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -9,20 +9,15 @@ Quick start
 
    export PETSC_CONFIGURE_OPTIONS="--download-suitesparse"
    curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install
-   python3 firedrake-install
+   python3 firedrake-install --install icepack
 
 * Active the Firedrake virtual environment::
 
    source <path/to/firedrake>/bin/activate
 
-* Clone and install icepack::
-
-   git clone https://github.com/icepack/icepack
-   cd icepack
-   pip3 install -e .
-
 * Run the icepack unit tests to make sure everything's working::
 
+   cd firedrake/src/icepack
    pytest -s
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+scipy
+matplotlib
+rasterio


### PR DESCRIPTION
Firedrake provides inbuilt support for installing icepack. This means Firedrake and icepack can be installed in a single line, which makes the icepack install instructions shorter.

As an aside, I note that the icepack install instructions also install umfpack. Firedrake builds mumps into PETSc to provide a good parallel direct solver. Is there something about umfpack which means we need that in addition to mumps?