### PR TITLE
eliminating icepack-data repo

### DIFF
--- a/demo/02-larsen-ice-shelf.ipynb
+++ b/demo/02-larsen-ice-shelf.ipynb
@@ -22,14 +22,23 @@
     "# Larsen Ice Shelf\n",
     "\n",
     "This demo will involve using real data for the Larsen Ice Shelf in the Antarctic Peninsula.\n",
-    "So far as the actual modeling is concerned, most of what we'll need was in the previous demo.\n",
-    "What's new here are the functions for reading in meshes and gridded data sets from files.\n",
+    "The use of real data will mostly change how we set up the simulation.\n",
+    "The simulation itself -- involving successive prognostic and diagnostic solves of the physics model -- is virtually identical to what we saw in the last demo.\n",
     "\n",
-    "The scripts I used to fetch and process all of this data are contained in [this repo](https://github.com/icepack/icepack-data).\n",
-    "To use it, clone the repository and run `make` in each of the directories `bedmap2/`, `measures-antarctica/`, and `meshes/larsen/`.\n",
-    "For this notebook, I'll assume that the absolute path of the data repository on your computer is stored in a variable `data_directory`.\n",
-    "In my case, I keep this in an environment variable called `ICEPACK_DATA`.\n",
-    "If you modify this notebook for your own uses, you can use whatever works for you to get the path right; the easiest way would probably be to hard-code `data_directory` to the right location on your computer."
+    "To access the data we'll use, you'll need to have a login for [EarthData](https://urs.earthdata.nasa.gov/), the web portal through which NASA makes remote sensing data available to the public.\n",
+    "Most of the ice sheet remote sensing data produced by American research institutions is hosted at the [National Snow and Ice Data Center (NSIDC)](https://www.nsidc.org) and an EarthData login is necessary to access data from NSIDC.\n",
+    "In particular, we'll use a velocity map of Antarctica produced as part of the MEaSUREs program, which you can read more about [here](https://nsidc.org/data/nsidc-0484).\n",
+    "For the ice thickness we'll use the [bedmap2](https://www.bas.ac.uk/project/bedmap-2/) data set, which is available from the British Antarctic Survey.\n",
+    "Finally, we'll need a description of the computational domain.\n",
+    "In this case, I created a vector data file of the outline of the Larsen Ice Shelf by tracing over satellite imagery in a [geographic information system](https://en.wikipedia.org/wiki/Geographic_information_system).\n",
+    "\n",
+    "Rather than manually download these data sets from the websites they're hosted on, we'll call a few functions in the module `data.py` in this directory to fetch them for us.\n",
+    "(Internally, these functions use a library called [pooch](https://github.com/fatiando/pooch) which handles things like caching the data so it doesn't get downloaded twice, unzipping archived files, and so forth.)\n",
+    "One we have the gridded data sets we'll use the library [rasterio](https://rasterio.readthedocs.io/en/stable/) to read them.\n",
+    "Both pooch and rasterio will have been installed along with icepack, so you don't need to do this yourself.\n",
+    "You will need to have a working installation of [gmsh](https://gmsh.info) in order to generate the mesh.\n",
+    "\n",
+    "First, we'll fetch the mesh and print out the path to the file where it's been stored."
    ]
   },
   {
@@ -38,8 +47,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_directory = os.environ['ICEPACK_DATA']\n",
-    "print(data_directory)"
+    "import data\n",
+    "mesh_filename = data.fetch_larsen_mesh()\n",
+    "print(mesh_filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This function will put the mesh in a predictable location on your system so it can be found easily later, and it will only download the file the first time you ask for it.\n",
+    "The caching aspect will come in handy because we'll be using much of the same data in the fourth demo.\n",
+    "The data module contains functions to fetch the remaining data, which we'll see below."
    ]
   },
   {
@@ -48,20 +67,10 @@
    "source": [
     "### Geometry\n",
     "\n",
-    "First we need to make a mesh.\n",
-    "I go about this by hand-drawing the domain boundary in [QGIS](https://www.qgis.org) on top of satellite imagery and whatever other gridded data sets I'm working with.\n",
-    "I always save these vector data in the [GeoJSON](http://geojson.org/) format rather than, say, an ESRI shapefile.\n",
-    "GeoJSON is human-readable and easy to keep in version control.\n",
-    "The GeoJSON files for the outline of Larsen are in the directory of `meshes/larsen/` of the [data repo](https://github.com/icepack/icepack-data).\n",
-    "That said, this is my own peculiar workflow and yours might differ.\n",
-    "\n",
-    "The domain outline is then transformed into whatever file format your mesh generator of choice can read.\n",
-    "For this example, I used [gmsh](http://gmsh.info/).\n",
-    "Finally, we invoke the mesh generator to turn our description of the outline into a mesh of the interior of the domain.\n",
-    "\n",
+    "Now that we've downloaded the mesh we need to read it.\n",
     "Firedrake has built-in functions for reading meshes in a variety of formats.\n",
     "The following code reads in the Larsen mesh and makes a plot of it so that we can see all the boundary IDs.\n",
-    "Boundary segments 1 and 2 correspond to the calving terminus; segment 3 borders the Gipps Ice Rise."
+    "Boundary segments 1 and 3 correspond to the calving terminus; segment 2 borders the Gipps Ice Rise."
    ]
   },
   {
@@ -70,7 +79,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mesh = firedrake.Mesh(os.path.join(data_directory, 'meshes', 'larsen', 'larsen.msh'))\n",
+    "mesh = firedrake.Mesh(mesh_filename)\n",
     "\n",
     "fig, axes = icepack.plot.subplots()\n",
     "axes.set_xlabel('meters')\n",
@@ -85,13 +94,45 @@
    "source": [
     "### Input data\n",
     "\n",
-    "Next, we have to load the input data.\n",
-    "We'll use ice thickness data from [Bedmap2](https://www.bas.ac.uk/project/bedmap-2/) and velocity data from [MEaSUREs](https://nsidc.org/data/measures/aiv).\n",
-    "The scripts in the `bedmap2` and `measures-antarctica` directories of the [data repo](https://github.com/icepack/icepack-data) fetch these data sets from their various hosts online.\n",
-    "\n",
-    "First, we'll read in the thickness data, which are stored in the [GeoTIFF](https://en.wikipedia.org/wiki/GeoTIFF) format.\n",
+    "Next, we have to load the input data, starting with the ice thickness.\n",
+    "The bedmap2 dataset that we use actually includes several fields -- thickness, surface elevation, bed elevation, an ice shelf and rock mask, etc.\n",
+    "The function `fetch_bedmap2` will download the dataset from the internet, unzip it, and return a list of the paths of all the files it retrieved rather than just a single file like the `fetch_larsen_mesh` function did."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bedmap2_files = data.fetch_bedmap2()\n",
+    "for filename in bedmap2_files:\n",
+    "    print(filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We're only interested in the thickness data itself, so the following command will pull it out from the list of all the other files in the bedmap2 dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thickness_filename = [f for f in bedmap2_files if\n",
+    "                      os.path.basename(f) == 'bedmap2_thickness.tif'][0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The thickness data are stored in a [GeoTIFF](https://en.wikipedia.org/wiki/GeoTIFF) file.\n",
     "GeoTIFF is a common storage format for geospatial data; it adds georeferencing information on top of the TIFF file format, which is often used for lossless compression of images.\n",
-    "We'll use the [rasterio](https://rasterio.readthedocs.io/en/stable/) package, which has functions to open GeoTIFF and other file formats.\n",
     "The function `rasterio.open` will give us an object representing the raster data set that we can then read from."
    ]
   },
@@ -101,8 +142,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bedmap2_filename = os.path.join(data_directory, 'bedmap2', 'bedmap2_tiff', 'bedmap2_thickness.tif')\n",
-    "thickness = rasterio.open(bedmap2_filename, 'r')"
+    "thickness = rasterio.open(thickness_filename, 'r')"
    ]
   },
   {
@@ -141,11 +181,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we have to read in the velocity data.\n",
-    "The velocity data are stored in a [NetCDF](https://en.wikipedia.org/wiki/NetCDF) file.\n",
-    "Many fields can be stored in one NetCDF file; we only want the $x$- and $y$-components of the velocity.\n",
-    "To specify which field we're reading, we can prepend `netcdf:` to the beginning of the filename and append `:FIELD_NAME` to the string we pass to `rasterio.open`.\n",
-    "The field names for the velocity components in this data set are `VX` and `VY`."
+    "Next, we have to fetch the velocity data, which are hosted on NSIDC.\n",
+    "The following will prompt for your EarthData login if need be.\n",
+    "The file is ~6GiB, so if you run this demo yourself, this step could take a while."
    ]
   },
   {
@@ -154,16 +192,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "measures_filename = os.path.join(data_directory, 'measures-antarctica', 'antarctica_ice_velocity_450m_v2.nc')\n",
-    "vx = rasterio.open('netcdf:' + measures_filename + ':VX', 'r')\n",
-    "vy = rasterio.open('netcdf:' + measures_filename + ':VY', 'r')"
+    "velocity_filename = data.fetch_measures_antarctica()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can see which variables are stored in a NetCDF file by running the shell command `ncinfo` on the file."
+    "The velocity data are stored in a [NetCDF](https://en.wikipedia.org/wiki/NetCDF) file.\n",
+    "NetCDF is another common storage format for geophysical data, especially in atmospheric science.\n",
+    "NetCDF offers much more freedom than GeoTIFF in terms of what kind of data can be stored, so you have to know something about the schema or layout before you use it.\n",
+    "For example, many fields can be stored by name in a NetCDF file, and you have to know what all the names are.\n",
+    "The script `ncinfo` will print out information about all the fields stored in a NetCDF file."
    ]
   },
   {
@@ -172,7 +212,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!ncinfo \"$measures_filename\""
+    "!ncinfo \"$velocity_filename\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The fields we want are `VX` and `VY`.\n",
+    "We can use rasterio can read NetCDF files too, but we have to add in a bit of extra magic so it'll know that we want to get the `VX` and `VY`.\n",
+    "To specify which field we're reading, we can prepend `netcdf:` to the beginning of the filename and append `:FIELD_NAME` to the string we pass to `rasterio.open`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vx = rasterio.open('netcdf:' + velocity_filename + ':VX', 'r')\n",
+    "vy = rasterio.open('netcdf:' + velocity_filename + ':VY', 'r')"
    ]
   },
   {
@@ -226,7 +285,7 @@
     "A = firedrake.interpolate(firedrake.Constant(icepack.rate_factor(T)), Q)\n",
     "\n",
     "ice_shelf = icepack.models.IceShelf()\n",
-    "opts = {'dirichlet_ids': [3, 4, 5, 6, 7, 8], 'tol': 1e-6}\n",
+    "opts = {'dirichlet_ids': [2, 4, 5, 6, 7, 8], 'tol': 1e-6}\n",
     "u = ice_shelf.diagnostic_solve(u0=u0, h=h0, A=A, **opts)"
    ]
   },

--- a/demo/02-larsen-ice-shelf.ipynb
+++ b/demo/02-larsen-ice-shelf.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import os, os.path\n",
+    "import os\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import rasterio\n",
@@ -87,12 +87,12 @@
     "\n",
     "Next, we have to load the input data.\n",
     "We'll use ice thickness data from [Bedmap2](https://www.bas.ac.uk/project/bedmap-2/) and velocity data from [MEaSUREs](https://nsidc.org/data/measures/aiv).\n",
-    "These data sets are large and not all in the same format.\n",
-    "The scripts in the `bedmap2` and `measures-antarctica` directories of the [data repo](https://github.com/icepack/icepack-data) fetch the data from the original sources, divide them up into subsets for several interesting regions in Antarctica, and save them as [GeoTIFF](https://en.wikipedia.org/wiki/GeoTIFF) files.\n",
-    "GeoTIFF is a common storage format for gridded data that adds georeferencing metadata on top of the TIFF image file format.\n",
+    "The scripts in the `bedmap2` and `measures-antarctica` directories of the [data repo](https://github.com/icepack/icepack-data) fetch these data sets from their various hosts online.\n",
     "\n",
-    "The code below uses the package [rasterio](https://rasterio.readthedocs.io/en/stable/) to open the thickness and velocity maps.\n",
-    "Later, we'll interpolate these gridded data sets to the mesh."
+    "First, we'll read in the thickness data, which are stored in the [GeoTIFF](https://en.wikipedia.org/wiki/GeoTIFF) format.\n",
+    "GeoTIFF is a common storage format for geospatial data; it adds georeferencing information on top of the TIFF file format, which is often used for lossless compression of images.\n",
+    "We'll use the [rasterio](https://rasterio.readthedocs.io/en/stable/) package, which has functions to open GeoTIFF and other file formats.\n",
+    "The function `rasterio.open` will give us an object representing the raster data set that we can then read from."
    ]
   },
   {
@@ -101,18 +101,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "thickness = rasterio.open(os.path.join(data_directory, 'bedmap2', 'larsen-h.tif'), 'r')\n",
-    "vx = rasterio.open(os.path.join(data_directory, 'measures-antarctica', 'larsen-vx.tif'), 'r')\n",
-    "vy = rasterio.open(os.path.join(data_directory, 'measures-antarctica', 'larsen-vy.tif'), 'r')"
+    "bedmap2_filename = os.path.join(data_directory, 'bedmap2', 'bedmap2_tiff', 'bedmap2_thickness.tif')\n",
+    "thickness = rasterio.open(bedmap2_filename, 'r')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before going on, let's make a plot of the thickness data set.\n",
-    "The function `contourf` in the module `icepack.plot` will call out to the equivalent matplotlib function before first getting all the axis limits right for the extent of the data set.\n",
-    "Plotting all your data first is a good sanity check to make sure that it isn't, say, stored upside-down, or in a different coordinate system than you expected."
+    "Opening the file doesn't immediately read all the data at once.\n",
+    "Instead, that occurs through calls to the `read` method of the data set, in our case the variable `thickness`.\n",
+    "The actual reading will occur entirely within the functions that interpolate the raster data to our computational mesh.\n",
+    "This two-step procedure involves a little extra code, but the nice part is that you can read only as small a chunk of the data as need be.\n",
+    "It would be awfully wasteful if you had to load up the thickness of all of Antarctica only to focus on a little piece like the Larsen Ice Shelf."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before going on, let's make a plot of the thickness data.\n",
+    "Plotting all your data first is a good sanity check to make sure that it isn't, say, stored upside-down, or in a different coordinate system than you expected.\n",
+    "To visualize our data, we'll use the function `contourf` in the module `icepack.plot`, which works just like the equivalent matplotlib function."
    ]
   },
   {
@@ -122,9 +132,47 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.contourf(thickness, levels=np.linspace(0, 625, 26), axes=axes)\n",
+    "contours = icepack.plot.contourf(thickness, 40, axes=axes)\n",
     "fig.colorbar(contours, label='meters')\n",
     "plt.show(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we have to read in the velocity data.\n",
+    "The velocity data are stored in a [NetCDF](https://en.wikipedia.org/wiki/NetCDF) file.\n",
+    "Many fields can be stored in one NetCDF file; we only want the $x$- and $y$-components of the velocity.\n",
+    "To specify which field we're reading, we can prepend `netcdf:` to the beginning of the filename and append `:FIELD_NAME` to the string we pass to `rasterio.open`.\n",
+    "The field names for the velocity components in this data set are `VX` and `VY`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "measures_filename = os.path.join(data_directory, 'measures-antarctica', 'antarctica_ice_velocity_450m_v2.nc')\n",
+    "vx = rasterio.open('netcdf:' + measures_filename + ':VX', 'r')\n",
+    "vy = rasterio.open('netcdf:' + measures_filename + ':VY', 'r')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can see which variables are stored in a NetCDF file by running the shell command `ncinfo` on the file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ncinfo \"$measures_filename\""
    ]
   },
   {
@@ -149,8 +197,8 @@
    "outputs": [],
    "source": [
     "degree = 2\n",
-    "Q = firedrake.FunctionSpace(mesh, 'CG', degree)\n",
-    "V = firedrake.VectorFunctionSpace(mesh, 'CG', degree)\n",
+    "Q = firedrake.FunctionSpace(mesh, family='CG', degree=degree)\n",
+    "V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=degree)\n",
     "\n",
     "h0 = icepack.interpolate(thickness, Q)\n",
     "u0 = icepack.interpolate((vx, vy), V)"

--- a/demo/04-ice-shelf-inverse.ipynb
+++ b/demo/04-ice-shelf-inverse.ipynb
@@ -103,11 +103,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "thickness = rasterio.open(os.path.join(data_directory, 'bedmap2', 'larsen-h.tif'), 'r')\n",
-    "vx = rasterio.open(os.path.join(data_directory, 'measures-antarctica', 'larsen-vx.tif'), 'r')\n",
-    "vy = rasterio.open(os.path.join(data_directory, 'measures-antarctica', 'larsen-vy.tif'), 'r')\n",
-    "stdx = rasterio.open(os.path.join(data_directory, 'measures-antarctica', 'larsen-stdx.tif'), 'r')\n",
-    "stdy = rasterio.open(os.path.join(data_directory, 'measures-antarctica', 'larsen-stdy.tif'), 'r')"
+    "bedmap2_filename = os.path.join(data_directory, 'bedmap2', 'bedmap2_tiff', 'bedmap2_thickness.tif')\n",
+    "thickness = rasterio.open(bedmap2_filename, 'r')\n",
+    "\n",
+    "measures_filename = os.path.join(data_directory, 'measures-antarctica', 'antarctica_ice_velocity_450m_v2.nc')\n",
+    "vx = rasterio.open('netcdf:' + measures_filename + ':VX', 'r')\n",
+    "vy = rasterio.open('netcdf:' + measures_filename + ':VY', 'r')\n",
+    "stdx = rasterio.open('netcdf:' + measures_filename + ':STDX', 'r')\n",
+    "stdy = rasterio.open('netcdf:' + measures_filename + ':STDY', 'r')"
    ]
   },
   {
@@ -117,8 +120,8 @@
    "outputs": [],
    "source": [
     "degree = 2\n",
-    "Q = firedrake.FunctionSpace(mesh, 'CG', degree)\n",
-    "V = firedrake.VectorFunctionSpace(mesh, 'CG', degree)\n",
+    "Q = firedrake.FunctionSpace(mesh, family='CG', degree=degree)\n",
+    "V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=degree)\n",
     "\n",
     "h = icepack.interpolate(thickness, Q)\n",
     "u_obs = icepack.interpolate((vx, vy), V)\n",

--- a/demo/04-ice-shelf-inverse.ipynb
+++ b/demo/04-ice-shelf-inverse.ipynb
@@ -79,16 +79,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_directory = os.environ['ICEPACK_DATA']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mesh = firedrake.Mesh(os.path.join(data_directory, 'meshes', 'larsen', 'larsen.msh'))\n",
+    "import data\n",
+    "mesh_filename = data.fetch_larsen_mesh()\n",
+    "mesh = firedrake.Mesh(mesh_filename)\n",
     "\n",
     "fig, axes = icepack.plot.subplots()\n",
     "axes.set_xlabel('meters')\n",
@@ -103,14 +96,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bedmap2_filename = os.path.join(data_directory, 'bedmap2', 'bedmap2_tiff', 'bedmap2_thickness.tif')\n",
-    "thickness = rasterio.open(bedmap2_filename, 'r')\n",
+    "thickness_filename = [f for f in data.fetch_bedmap2() if\n",
+    "                      os.path.basename(f) == 'bedmap2_thickness.tif'][0]\n",
+    "velocity_filename = data.fetch_measures_antarctica()\n",
     "\n",
-    "measures_filename = os.path.join(data_directory, 'measures-antarctica', 'antarctica_ice_velocity_450m_v2.nc')\n",
-    "vx = rasterio.open('netcdf:' + measures_filename + ':VX', 'r')\n",
-    "vy = rasterio.open('netcdf:' + measures_filename + ':VY', 'r')\n",
-    "stdx = rasterio.open('netcdf:' + measures_filename + ':STDX', 'r')\n",
-    "stdy = rasterio.open('netcdf:' + measures_filename + ':STDY', 'r')"
+    "thickness = rasterio.open(thickness_filename, 'r')\n",
+    "vx = rasterio.open('netcdf:' + velocity_filename + ':VX', 'r')\n",
+    "vy = rasterio.open('netcdf:' + velocity_filename + ':VY', 'r')\n",
+    "stdx = rasterio.open('netcdf:' + velocity_filename + ':STDX', 'r')\n",
+    "stdy = rasterio.open('netcdf:' + velocity_filename + ':STDY', 'r')"
    ]
   },
   {
@@ -174,7 +168,7 @@
     "θ = firedrake.Function(Q)\n",
     "\n",
     "ice_shelf = icepack.models.IceShelf(viscosity=viscosity)\n",
-    "opts = {'dirichlet_ids': [3, 4, 5, 6, 7, 8], 'tol': 1e-6}\n",
+    "opts = {'dirichlet_ids': [2, 4, 5, 6, 7, 8], 'tol': 1e-6}\n",
     "u = ice_shelf.diagnostic_solve(u0=u_obs, h=h, θ=θ, **opts)"
    ]
   },

--- a/demo/data.py
+++ b/demo/data.py
@@ -1,0 +1,69 @@
+import os
+from getpass import getpass
+import subprocess
+import requests
+import pooch
+import mesh
+
+measures_antarctica = pooch.create(
+    path=pooch.os_cache('icepack'),
+    base_url='https://n5eil01u.ecs.nsidc.org/MEASURES/NSIDC-0484.002/1996.01.01/',
+    registry={
+        'antarctica_ice_velocity_450m_v2.nc':
+        '268be94e3827b9b8137b4b81e3642310ca98a1b9eac48e47f91d53c1b51e4299'
+    }
+)
+
+def _earthdata_downloader(url, output_file, dataset):
+    username = os.environ.get('EARTHDATA_USERNAME')
+    if username is None:
+        username = input('EarthData username: ')
+
+    password = os.environ.get('EARTHDATA_PASSWORD')
+    if password is None:
+        password = getpass('EarthData password: ')
+
+    login = requests.get(url)
+    downloader = pooch.HTTPDownloader(auth=(username, password))
+    downloader(login.url, output_file, dataset)
+
+def fetch_measures_antarctica():
+    return measures_antarctica.fetch('antarctica_ice_velocity_450m_v2.nc',
+                                     downloader=_earthdata_downloader)
+
+bedmap2 = pooch.create(
+    path=pooch.os_cache('icepack'),
+    base_url='https://secure.antarctica.ac.uk/data/bedmap2/',
+    registry={
+        'bedmap2_tiff.zip':
+        'f4bb27ce05197e9d29e4249d64a947b93aab264c3b4e6cbf49d6b339fb6c67fe'
+    }
+)
+
+def fetch_bedmap2():
+    filenames = bedmap2.fetch('bedmap2_tiff.zip', processor=pooch.Unzip())
+    return [f for f in filenames if os.path.splitext(f)[1] == '.tif']
+
+
+larsen_outline = pooch.create(
+    path=pooch.os_cache('icepack'),
+    base_url='https://raw.githubusercontent.com/icepack/glacier-meshes/master/glaciers/',
+    registry={
+        'larsen.geojson':
+        '06a0ae21a3a55a8391ff32eefb69e0e0ec8f29bca68d9bc4cd23abb5010397f8'
+    }
+)
+
+
+def _generate_mesh(geojson_filename, action, dataset):
+    msh_filename = os.path.splitext(geojson_filename)[0] + '.msh'
+    if action in ('update', 'download') or not os.path.exists(msh_filename):
+        geo_filename = os.path.splitext(geojson_filename)[0] + '.geo'
+        mesh.main(geojson_filename, geo_filename)
+        subprocess.call(['gmsh', '-2', '-format', 'msh2', geo_filename])
+
+    return msh_filename
+
+
+def fetch_larsen_mesh():
+    return larsen_outline.fetch('larsen.geojson', processor=_generate_mesh)

--- a/demo/mesh.py
+++ b/demo/mesh.py
@@ -1,0 +1,58 @@
+import sys
+import geojson
+import pygmsh
+
+
+def add_loop_to_geometry(geometry, multi_line_string):
+    line_loop = []
+    for line_index, line_string in enumerate(multi_line_string):
+        arc = []
+        for index in range(len(line_string) - 1):
+            x1 = line_string[index]
+            x2 = line_string[index + 1]
+            arc.append(geometry.add_line(x1, x2))
+
+        num_lines = len(multi_line_string)
+        next_line_string = multi_line_string[(line_index + 1) % num_lines]
+        x1 = line_string[-1]
+        x2 = next_line_string[0]
+        arc.append(geometry.add_line(x1, x2))
+
+        geometry.add_physical(arc)
+        line_loop.extend(arc)
+
+    return geometry.add_line_loop(line_loop)
+
+
+def collection_to_geo(collection, lcar=10e3):
+    geometry = pygmsh.built_in.Geometry()
+
+    features = collection['features']
+    num_features = len(features)
+
+    points = [[[geometry.add_point((point[0], point[1], 0.), lcar=lcar)
+                for point in line_string[:-1]]
+               for line_string in feature['geometry']['coordinates']]
+              for feature in features]
+
+    line_loops = [add_loop_to_geometry(geometry, multi_line_string)
+                  for multi_line_string in points]
+    plane_surface = geometry.add_plane_surface(line_loops[0],
+                                               holes=line_loops[1:])
+    physical_surface = geometry.add_physical(plane_surface)
+
+    return geometry
+
+
+def main(input_filename, output_filename):
+    with open(input_filename, 'r') as input_file:
+        collection = geojson.load(input_file)
+
+    outline = collection_to_geo(collection, lcar=10e3)
+    with open(output_filename, 'w') as output_file:
+        output_file.write(outline.get_code())
+
+if __name__ == '__main__':
+    input_filename = sys.argv[1]
+    output_filename = sys.argv[2]
+    main(input_filename, output_filename)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,10 +1,3 @@
-# This environment variable needs to be set in order to find the data sets used
-# for some of the demos.
-check-env:
-ifndef ICEPACK_DATA
-    $(error ICEPACK_DATA is undefined)
-endif
-
 source/index.rst: make_index.py
 	python3 make_index.py $(DEMO_FILES)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ numpy
 scipy
 matplotlib
 rasterio
+geojson
+pooch
+pygmsh

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,6 @@ setup(
     author='Daniel Shapero',
     url='https://github.com/icepack/icepack',
     packages=find_packages(exclude=['doc', 'test']),
-    install_requires=['firedrake', 'numpy', 'scipy', 'matplotlib', 'rasterio']
+    install_requires=['firedrake', 'numpy', 'scipy', 'matplotlib', 'rasterio',
+                      'geojson', 'pooch', 'pygmsh']
 )


### PR DESCRIPTION
This patch eliminates nearly all the functions of the icepack-data repo, which makes running the demos a lot simpler for the average user.