### PR TITLE
Lax-Wendroff

### DIFF
--- a/icepack/models/ice_shelf.py
+++ b/icepack/models/ice_shelf.py
@@ -16,7 +16,7 @@ from icepack.constants import (ice_density as ρ_I, water_density as ρ_W,
                                gravity as g)
 from icepack.models.viscosity import viscosity_depth_averaged as viscosity
 from icepack.models.friction import side_friction, normal_flow_penalty
-from icepack.models.mass_transport import MassTransport
+from icepack.models.mass_transport import LaxWendroff
 from icepack.optimization import newton_search
 from icepack.utilities import add_kwarg_wrapper
 
@@ -74,8 +74,9 @@ class IceShelf(object):
           Default implementation of the ice shelf viscous action
     """
     def __init__(self, viscosity=viscosity, gravity=gravity, terminus=terminus,
-                 side_friction=side_friction, penalty=normal_flow_penalty):
-        self.mass_transport = MassTransport()
+                 side_friction=side_friction, penalty=normal_flow_penalty,
+                 mass_transport=LaxWendroff()):
+        self.mass_transport = mass_transport
         self.viscosity = add_kwarg_wrapper(viscosity)
         self.side_friction = add_kwarg_wrapper(side_friction)
         self.penalty = add_kwarg_wrapper(penalty)
@@ -188,9 +189,9 @@ class IceShelf(object):
         return newton_search(action, u, bcs, tol, scale,
                              form_compiler_parameters=params)
 
-    def prognostic_solve(self, dt, h0, a, u, **kwargs):
+    def prognostic_solve(self, dt, h0, a, u, h_inflow=None):
         r"""Propagate the ice thickness forward one timestep
 
         See :meth:`icepack.models.mass_transport.MassTransport.solve`
         """
-        return self.mass_transport.solve(dt, h0=h0, a=a, u=u, **kwargs)
+        return self.mass_transport.solve(dt, h0=h0, a=a, u=u, h_inflow=h_inflow)

--- a/icepack/models/ice_stream.py
+++ b/icepack/models/ice_stream.py
@@ -17,7 +17,7 @@ from icepack.constants import (ice_density as ρ_I, water_density as ρ_W,
 from icepack.models.viscosity import viscosity_depth_averaged as viscosity
 from icepack.models.friction import (bed_friction, side_friction,
                                      normal_flow_penalty)
-from icepack.models.mass_transport import MassTransport
+from icepack.models.mass_transport import LaxWendroff
 from icepack.optimization import newton_search
 from icepack.utilities import add_kwarg_wrapper
 
@@ -87,11 +87,11 @@ class IceStream(object):
        :py:func:`icepack.models.viscosity.viscosity_depth_averaged`
           Default implementation of the ice stream viscous action
     """
-
     def __init__(self, viscosity=viscosity, friction=bed_friction,
                  side_friction=side_friction, penalty=normal_flow_penalty,
-                 gravity=gravity, terminus=terminus):
-        self.mass_transport = MassTransport()
+                 gravity=gravity, terminus=terminus,
+                 mass_transport=LaxWendroff()):
+        self.mass_transport = mass_transport
         self.viscosity = add_kwarg_wrapper(viscosity)
         self.friction = add_kwarg_wrapper(friction)
         self.side_friction = add_kwarg_wrapper(side_friction)
@@ -181,12 +181,12 @@ class IceStream(object):
         return newton_search(action, u, bcs, tol, scale,
                              form_compiler_parameters=params)
 
-    def prognostic_solve(self, dt, h0, a, u, **kwargs):
+    def prognostic_solve(self, dt, h0, a, u, h_inflow=None):
         r"""Propagate the ice thickness forward one timestep
 
-        See :meth:`icepack.models.mass_transport.MassTransport.solve`
+        See :meth:`icepack.models.mass_transport.ImplicitEuler.solve`
         """
-        return self.mass_transport.solve(dt, h0=h0, a=a, u=u, **kwargs)
+        return self.mass_transport.solve(dt, h0=h0, a=a, u=u, h_inflow=h_inflow)
 
     def compute_surface(self, h, b):
         r"""Return the ice surface elevation consistent with a given

--- a/icepack/utilities.py
+++ b/icepack/utilities.py
@@ -26,6 +26,11 @@ def grad_2(q):
     return firedrake.as_tensor((q.dx(0), q.dx(1)))
 
 
+def div_2(q):
+    r"""Compute the horizontal divergence of a 3D field"""
+    return q[0].dx(0) + q[1].dx(1)
+
+
 def diameter(mesh):
     r"""Compute the diameter of the mesh in the L-infinity metric"""
     X = mesh.coordinates.dat.data_ro


### PR DESCRIPTION
Adds a Lax-Wendroff time-stepping scheme for the mass transport equation in addition to the implicit Euler scheme. This scheme converges at higher order and has better stability properties than implicit Euler The flow models now include an optional argument for which mass transport scheme they use.