### PR TITLE
switching from bedmap2 to BedMachine Antarctica

### DIFF
--- a/demo/02-larsen-ice-shelf.ipynb
+++ b/demo/02-larsen-ice-shelf.ipynb
@@ -7,7 +7,6 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import os\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import rasterio\n",
@@ -31,7 +30,7 @@
     "\n",
     "The external data that we will use are:\n",
     "\n",
-    "* an ice thickness map from the [bedmap2](https://www.bas.ac.uk/project/bedmap-2/) data set, which is available from the British Antarctic Survey\n",
+    "* the [BedMachine](https://nsidc.org/data/NSIDC-0756/versions/1) thickness map of Antarctica\n",
     "* a velocity map of Antarctica produced as part of the MEaSUREs program, which you can read more about [here](https://nsidc.org/data/nsidc-0484)\n",
     "* a satellite image of all of Antarctica taken from [MODIS](https://en.wikipedia.org/wiki/Moderate_Resolution_Imaging_Spectroradiometer)\n",
     "* an outline of the Larsen C Ice Shelf, which I created by tracing over this satellite image in a [geographic information system](https://en.wikipedia.org/wiki/Geographic_information_system).\n",
@@ -379,8 +378,7 @@
     "### Input data\n",
     "\n",
     "Next, we have to load the input data, starting with the ice thickness.\n",
-    "The bedmap2 dataset that we use actually includes several fields -- thickness, surface elevation, bed elevation, an ice shelf and rock mask, etc.\n",
-    "The function `fetch_bedmap2` will download the dataset from the internet, unzip it, and return a list of the paths of all the files it retrieved rather than just a single file like the `fetch_larsen_mesh` function did."
+    "The BedMachine Antarctica dataset is hosted on NSIDC; the function `fetch_bedmachine_antarctica` will prompt you for your EarthData login if need be and download the dataset from the internet."
    ]
   },
   {
@@ -389,17 +387,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bedmap2_files = icepack.datasets.fetch_bedmap2()\n",
-    "for filename in bedmap2_files:\n",
-    "    print(os.path.basename(filename))"
+    "thickness_filename = icepack.datasets.fetch_bedmachine_antarctica()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We're only interested in the thickness data itself, so the following command will pull it out from the list of all the other files in the bedmap2 dataset.\n",
-    "We can then read the thickness data just like we did for the image mosaic."
+    "The data are stored in a [NetCDF](https://en.wikipedia.org/wiki/NetCDF) file.\n",
+    "NetCDF is a common storage format for geophysical data, especially in atmospheric science.\n",
+    "NetCDF offers a lot more freedom than GeoTIFF in terms of what kind of data can be stored and how, so you have to know something about the schema or layout before you use it.\n",
+    "For example, many fields can be stored by name in a NetCDF file, and you have to know what all the names are.\n",
+    "The script `ncinfo` will print out information about all the fields stored in a NetCDF file."
    ]
   },
   {
@@ -408,18 +407,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "thickness_filename = [f for f in bedmap2_files if\n",
-    "                      os.path.basename(f) == 'bedmap2_thickness.tif'][0]\n",
-    "\n",
-    "thickness = rasterio.open(thickness_filename, 'r')"
+    "!ncinfo \"$thickness_filename\""
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we have to fetch the velocity data, which are hosted on NSIDC.\n",
-    "The following will prompt for your EarthData login if need be.\n",
+    "From this information we can see that the name of the field we want is `thickness`.\n",
+    "We can use rasterio to read NetCDF files, but we have to add in a bit of extra magic so that it knows which field to extract from the file.\n",
+    "To specify which field we're reading, we can prepend `netcdf:` to the beginning of the filename and append `:FIELD_NAME` to the string we pass to `rasterio.open`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thickness = rasterio.open('netcdf:' + thickness_filename + ':thickness', 'r')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we have to fetch the velocity data, which are also hosted on NSIDC.\n",
     "The file is ~6GiB, so if you run this demo yourself, this step could take a while."
    ]
   },
@@ -436,29 +449,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The velocity data are stored in a [NetCDF](https://en.wikipedia.org/wiki/NetCDF) file.\n",
-    "NetCDF is another common storage format for geophysical data, especially in atmospheric science.\n",
-    "NetCDF offers much more freedom than GeoTIFF in terms of what kind of data can be stored, so you have to know something about the schema or layout before you use it.\n",
-    "For example, many fields can be stored by name in a NetCDF file, and you have to know what all the names are.\n",
-    "The script `ncinfo` will print out information about all the fields stored in a NetCDF file."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ncinfo \"$velocity_filename\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "The fields we want are `VX` and `VY`.\n",
-    "We can use rasterio can read NetCDF files too, but we have to add in a bit of extra magic so it'll know that we want to get the `VX` and `VY`.\n",
-    "To specify which field we're reading, we can prepend `netcdf:` to the beginning of the filename and append `:FIELD_NAME` to the string we pass to `rasterio.open`."
+    "The velocity dataset is also stored as a NetCDF file; the names of the fields we want are `VX` and `VY`."
    ]
   },
   {
@@ -512,17 +504,160 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll set up the model in the same way as the synthetic ice shelf demo, but there are more boundary segments for which we need to apply Dirichlet conditions."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "T = 260\n",
-    "A = firedrake.interpolate(firedrake.Constant(icepack.rate_factor(T)), Q)\n",
-    "\n",
+    "A = firedrake.Constant(icepack.rate_factor(T))\n",
     "ice_shelf = icepack.models.IceShelf()\n",
-    "opts = {'dirichlet_ids': [2, 4, 5, 6, 7, 8, 9], 'tol': 1e-6}\n",
-    "u = ice_shelf.diagnostic_solve(u0=u0, h=h0, A=A, **opts)"
+    "opts = {'dirichlet_ids': [2, 4, 5, 6, 7, 8, 9], 'tol': 1e-6}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we'll try to solve the shallow shelf equations to obtain the initial ice velocity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    u = ice_shelf.diagnostic_solve(u0=u0, h=h0, A=A, **opts)\n",
+    "except:\n",
+    "    print('Oh no, nonlinear solver did not converge!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now we've got our first taste of how difficult working with real data can be!\n",
+    "Why did the nonlinear solver fail to converge?\n",
+    "The ice thickness map from BedMachine is fine enough to resolve pretty small-scale topography, even down to the depth of rifts in the ice shelf.\n",
+    "Having such a high-resolution dataset means that the thickness can jump over a very small distance.\n",
+    "This could result in an unphysically large driving stress, which is shown in the plot below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from icepack.constants import ice_density as ρ_I, water_density as ρ_W, gravity as g\n",
+    "from firedrake import grad\n",
+    "τ_d = firedrake.interpolate(-1e3 * ρ_I * g * (1 - ρ_I / ρ_W) * grad(h0**2), V)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = icepack.plot.subplots()\n",
+    "contours = icepack.plot.tricontourf(τ_d, np.linspace(0., 100., 51),\n",
+    "                                    extend='max', axes=axes)\n",
+    "fig.colorbar(contours, label='kPa')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In many regions the driving stress exceeds 100 kilopascals, which would be reasonable for a steep Greenland outlet glacier, not for a floating ice shelf.\n",
+    "A quick hack around this would be to apply a smoothing filter to the ice thickness.\n",
+    "The code below synthesizes a new thickness `h` that matches the observations `h0` as best as possible while also supressing oscillations on scales less than 2km."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firedrake import assemble, inner, dx\n",
+    "h = h0.copy(deepcopy=True)\n",
+    "α = firedrake.Constant(2e3)\n",
+    "J = 0.5 * (h - h0)**2 * dx + 0.5 * α**2 * inner(grad(h), grad(h)) * dx\n",
+    "F = firedrake.derivative(J, h)\n",
+    "firedrake.solve(F == 0, h)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The relative difference between the raw and smoothed thickness is around 3.5%.\n",
+    "The errors from the correction for air or water in the firn column are around this magnitude or higher."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(assemble(abs(h - h0) * dx) / assemble(h * dx))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The driving stress of the filtered ice thickness tops out around 20 kPa, which is much more reasonable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "τ_d = firedrake.interpolate(-1e3 * ρ_I * g * (1 - ρ_I / ρ_W) * grad(h**2), V)\n",
+    "fig, axes = icepack.plot.subplots()\n",
+    "contours = icepack.plot.tricontourf(τ_d, np.linspace(0., 20., 41),\n",
+    "                                    extend='max', axes=axes)\n",
+    "fig.colorbar(contours, label='kPa')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With this regularized input data the nonlinear solver converges.\n",
+    "In general, the nonlinear solvers in icepack should always converge on reasonable input data, and sometimes even on unreasonable data too.\n",
+    "A sharp gradient in an overly-resolved thickness field, however, will create such large driving stresses as to no longer be reasonable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "u = ice_shelf.diagnostic_solve(u0=u0, h=h, A=A, **opts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The computed velocity is shown below; the result looks pretty reasonable if we're going by the speeds."
    ]
   },
   {
@@ -541,7 +676,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We get a fairly reasonable approximation for the velocity even with a spatially homogeneous guess for the ice temperature."
+    "As a further sanity check, we can see how far off the computed velocity is from the observed values.\n",
+    "We get a fairly reasonable approximation even with a spatially homogeneous guess for the ice temperature."
    ]
   },
   {
@@ -569,12 +705,13 @@
    "outputs": [],
    "source": [
     "a = firedrake.Function(Q)\n",
-    "h = h0.copy(deepcopy=True)\n",
+    "h_init = h.copy(deepcopy=True)\n",
     "\n",
-    "dt = 0.5\n",
-    "num_steps = int(10 / dt)\n",
-    "for n in range(num_steps + 1):\n",
-    "    h = ice_shelf.prognostic_solve(dt, h0=h, a=a, u=u, h_inflow=h0)\n",
+    "final_time = 10.\n",
+    "num_steps = 40\n",
+    "dt = final_time / num_steps\n",
+    "for step in range(num_steps + 1):\n",
+    "    h = ice_shelf.prognostic_solve(dt, h0=h, a=a, u=u, h_inflow=h_init)\n",
     "    u = ice_shelf.diagnostic_solve(u0=u, h=h, A=A, **opts)"
    ]
   },
@@ -613,7 +750,7 @@
    "outputs": [],
    "source": [
     "δh = firedrake.Function(Q)\n",
-    "δh.assign(h - h0)\n",
+    "δh.assign(h - h_init)\n",
     "\n",
     "fig, axes = subplots()\n",
     "contours = icepack.plot.tricontourf(δh, axes=axes, cmap='RdBu', alpha=0.25,\n",
@@ -626,7 +763,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The oscillatory pattern makes it less than obvious whether the ice shelf gained or lost mass, so let's evaluate the integral of the thickness change to see."
+    "The greatest mass losses occurred nearest to the calving terminus.\n",
+    "The pattern in mass change near the rifts on the right edge of the domain is more from advecting those oscillations downstream.\n",
+    "From the overall pattern, it's clear that the ice shelf is losing mass.\n",
+    "To see exactly how much, we can integrate the total thickness change and divide by the area of the shelf."
    ]
   },
   {
@@ -635,15 +775,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from firedrake import assemble, dx\n",
-    "print(assemble(δh * dx) / assemble(1 * dx(mesh)))"
+    "area = assemble(firedrake.Constant(1) * dx(mesh))\n",
+    "print(assemble(δh * dx) / area)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Seeing as the simulation ran for 10 years, this isn't a wildly unrealistic number."
+    "Seeing as the simulation ran for 10 years, this isn't a wildly unrealistic number.\n",
+    "Instead of guessing the net accumulation rate, we could improve the fidelity of our simulation by forcing it with the output of a climate model."
    ]
   },
   {

--- a/demo/02-larsen-ice-shelf.ipynb
+++ b/demo/02-larsen-ice-shelf.ipynb
@@ -478,11 +478,11 @@
     "### Modeling\n",
     "\n",
     "Having done all the leg work to make a mesh and get a good set of input data, the modeling itself should be fairly familiar from the last step.\n",
-    "We'll assume that the ice temperature is a uniform $-13^\\circ$C.\n",
+    "We'll assume that the ice temperature is a uniform -13${}^\\circ$C.\n",
     "\n",
     "One thing is substantially different from previous examples.\n",
     "Before, we called the function `firedrake.SpatialCoordinate` to get some symbolic handles `x, y` for the mesh coordinates, and we created symbolic expressions to define the input data to our problem analytically.\n",
-    "When we work with real data, we instead use icepack's `GridData` object, which firedrake doesn't know how to interpolate.\n",
+    "Now that we're working with real glaciers, we're reading in all the observational data using rasterio, but Firedrake doesn't know how to interpolate a rasterio dataset.\n",
     "The function `icepack.interpolate` works as a layer on top of the firedrake interpolate function and knows what to do with gridded data sets."
    ]
   },

--- a/demo/04-ice-shelf-inverse.ipynb
+++ b/demo/04-ice-shelf-inverse.ipynb
@@ -7,7 +7,6 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import os\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import rasterio\n",
@@ -71,7 +70,7 @@
    "source": [
     "### Input data\n",
     "\n",
-    "The input data are just as in the previous demo for the Larsen Ice Shelf, but we also need to use the error estimates for the velocities."
+    "The input data are the same as from the previous demo of the Larsen Ice Shelf."
    ]
   },
   {
@@ -153,20 +152,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "thickness_filename = [f for f in icepack.datasets.fetch_bedmap2() if\n",
-    "                      os.path.basename(f) == 'bedmap2_thickness.tif'][0]\n",
-    "velocity_filename = icepack.datasets.fetch_measures_antarctica()\n",
-    "\n",
-    "thickness = rasterio.open(thickness_filename, 'r')\n",
-    "vx = rasterio.open('netcdf:' + velocity_filename + ':VX', 'r')\n",
-    "vy = rasterio.open('netcdf:' + velocity_filename + ':VY', 'r')\n",
-    "stdx = rasterio.open('netcdf:' + velocity_filename + ':STDX', 'r')\n",
-    "stdy = rasterio.open('netcdf:' + velocity_filename + ':STDY', 'r')"
+    "Just like in the 2nd demo, we'll apply the smoothing filter to the thickness, which is necessary to get a reasonable driving stress."
    ]
   },
   {
@@ -175,10 +164,41 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Q = firedrake.FunctionSpace(mesh, family='CG', degree=2)\n",
-    "V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=2)\n",
+    "thickness_filename = icepack.datasets.fetch_bedmachine_antarctica()\n",
+    "thickness = rasterio.open('netcdf:' + thickness_filename + ':thickness', 'r')\n",
     "\n",
-    "h = icepack.interpolate(thickness, Q)\n",
+    "Q = firedrake.FunctionSpace(mesh, family='CG', degree=2)\n",
+    "h0 = icepack.interpolate(thickness, Q)\n",
+    "\n",
+    "from firedrake import inner, grad, dx\n",
+    "h = h0.copy(deepcopy=True)\n",
+    "α = firedrake.Constant(2e3)\n",
+    "J = 0.5 * (h - h0)**2 * dx + 0.5 * α**2 * inner(grad(h), grad(h)) * dx\n",
+    "F = firedrake.derivative(J, h)\n",
+    "firedrake.solve(F == 0, h)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to the velocities themselves, we also need the estimates of the velocity measurement errors.\n",
+    "The fidelity of the measurements tells us how good a fit to the data we should expect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "velocity_filename = icepack.datasets.fetch_measures_antarctica()\n",
+    "vx = rasterio.open('netcdf:' + velocity_filename + ':VX', 'r')\n",
+    "vy = rasterio.open('netcdf:' + velocity_filename + ':VY', 'r')\n",
+    "stdx = rasterio.open('netcdf:' + velocity_filename + ':STDX', 'r')\n",
+    "stdy = rasterio.open('netcdf:' + velocity_filename + ':STDY', 'r')\n",
+    "\n",
+    "V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=2)\n",
     "u_obs = icepack.interpolate((vx, vy), V)\n",
     "σx = icepack.interpolate(stdx, Q)\n",
     "σy = icepack.interpolate(stdy, Q)"
@@ -269,13 +289,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from firedrake import inner, grad, dx\n",
     "import icepack.inverse\n",
     "\n",
     "def objective(u):\n",
-    "    return 0.5 * (((u[0] - u_obs[0]) / σx)**2 + ((u[1] - u_obs[1]) / σy)**2) * dx\n",
+    "    δu = u - u_obs\n",
+    "    return 0.5 * ((δu[0] / σx)**2 + (δu[1] / σy)**2) * dx\n",
     "\n",
-    "L = 5.5e3\n",
+    "L = firedrake.Constant(6.5e3)\n",
     "def regularization(θ):\n",
     "    return 0.5 * L**2 * inner(grad(θ), grad(θ)) * dx"
    ]
@@ -438,7 +458,7 @@
    "outputs": [],
    "source": [
     "fig, axes = subplots()\n",
-    "contours = icepack.plot.tricontourf(solver.parameter, np.linspace(-10, 10, 41),\n",
+    "contours = icepack.plot.tricontourf(solver.parameter, np.linspace(-8, 8, 17),\n",
     "                                    alpha=0.6, cmap='RdBu', extend='both', axes=axes)\n",
     "fig.colorbar(contours)\n",
     "plt.show(fig)"
@@ -452,8 +472,8 @@
    "source": [
     "A = firedrake.interpolate(A0 * firedrake.exp(-solver.parameter / n), Q)\n",
     "fig, axes = subplots()\n",
-    "contours = icepack.plot.tricontourf(A, levels=np.linspace(0, 50, 51),\n",
-    "                                    alpha=0.6, extend='both', axes=axes)\n",
+    "contours = icepack.plot.tricontourf(A, levels=np.linspace(0, 50, 26),\n",
+    "                                    alpha=0.6, extend='max', axes=axes)\n",
     "fig.colorbar(contours)\n",
     "plt.show(fig)"
    ]

--- a/icepack/datasets.py
+++ b/icepack/datasets.py
@@ -76,13 +76,13 @@ def fetch_bedmachine_antarctica():
 
 
 outlines_url = 'https://raw.githubusercontent.com/icepack/glacier-meshes/'
-outlines_commit = '9306972327a127c4c4bdd3b5f61d2102307c2baa'
+outlines_commit = 'a522188dadb9ba49d4848ba66cab8c90f9fda5d9'
 larsen_outline = pooch.create(
     path=pooch.os_cache('icepack'),
     base_url=outlines_url + outlines_commit + '/glaciers/',
     registry={
         'larsen.geojson':
-        '74a632fcb7832df1c2f2d8c04302cfcdb3c1e86e027b8de5ba10e98d14d94856'
+        'da77c1920191d415961347b43e18d5bc2ffd72ddb803c01fc24c68c5db0f3033'
     }
 )
 

--- a/icepack/datasets.py
+++ b/icepack/datasets.py
@@ -61,6 +61,20 @@ def fetch_bedmap2():
     return [f for f in filenames if os.path.splitext(f)[1] == '.tif']
 
 
+bedmachine_antarctica = pooch.create(
+    path=pooch.os_cache('icepack'),
+    base_url='https://n5eil01u.ecs.nsidc.org/MEASURES/NSIDC-0756.001/1970.01.01/',
+    registry={
+        'BedMachineAntarctica_2019-11-05_v01.nc':
+        '06a01511a51bbc27d5080e4727a6523126659fe62402b03654a5335e25b614c0'
+    }
+)
+
+def fetch_bedmachine_antarctica():
+    return bedmachine_antarctica.fetch('BedMachineAntarctica_2019-11-05_v01.nc',
+                                       downloader=_earthdata_downloader)
+
+
 outlines_url = 'https://raw.githubusercontent.com/icepack/glacier-meshes/'
 outlines_commit = '9306972327a127c4c4bdd3b5f61d2102307c2baa'
 larsen_outline = pooch.create(

--- a/icepack/interpolate.py
+++ b/icepack/interpolate.py
@@ -23,7 +23,7 @@ def interpolate(f, Q):
 
     Parameters
     ----------
-    f : icepack.grid.GridData or tuple of icepack.grid.GridData
+    f : rasterio dataset or tuple of rasterio datasets
         The gridded data set for scalar fields or the tuple of gridded data
         sets for each component
     Q : firedrake.FunctionSpace

--- a/icepack/plot.py
+++ b/icepack/plot.py
@@ -214,7 +214,7 @@ def streamline(velocity, initial_point, resolution, max_num_points=np.inf):
 
     Parameters
     ----------
-    velocity : firedrake.Function or tuple of icepack.grid.GridData
+    velocity : firedrake.Function
         the velocity field we are integrating
     initial_point : pair of floats
         the starting point for the streamline


### PR DESCRIPTION
Use the new [BedMachine](https://nsidc.org/data/NSIDC-0756/versions/1) dataset for Antarctica, which incorporates new observations that were not available when bedmap2 was compiled. Switching to the new dataset required changing the mesh for Larsen C and applying a smoothing filter to avoid some unphysical values of the ice thickness due to rifts, firn, etc.