### PR TITLE
Updating testing environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,14 +16,14 @@ commands:
 jobs:
   python35:
     docker:
-      - image: icepack/firedrake-python3.5:0.3.1
+      - image: icepack/firedrake-python3.5:0.3.2
     working_directory: ~/icepack
     steps:
       - build
       - test
   python37:
     docker:
-      - image: icepack/firedrake-python3.7:0.3.1
+      - image: icepack/firedrake-python3.7:0.3.2
     working_directory: ~/icepack
     steps:
       - build


### PR DESCRIPTION
This patch pulls in a newer docker image for testing that has gmsh installed. This way we can use more sophisticated geometries in the test suite or run the synthetic demos as part of the tests.