### PR TITLE
change where measures are applied to action functionals

### DIFF
--- a/demo/03-synthetic-ice-stream.ipynb
+++ b/demo/03-synthetic-ice-stream.ipynb
@@ -495,7 +495,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following function returns the action functional associated to this sliding law, given the ice velocity, elevation, and the yield stress."
+    "The following function returns the kernel of the action functional associated to this sliding law, given the ice velocity, elevation, and the yield stress.\n",
+    "Note that we only need to provide the inside of the integral -- the model object applies the measures (`dx`, `ds`, etc.) for you."
    ]
   },
   {
@@ -507,7 +508,7 @@
     "def schoof_friction(u, h, s, τ):\n",
     "    ϕ = 1 - ρ_W/ρ_I * firedrake.max_value(0, h - s) / h\n",
     "    U = sqrt(inner(u, u))\n",
-    "    return τ * ϕ * (u_threshold**(1/m + 1) + U**(1/m + 1))**(m/(m + 1)) * dx"
+    "    return τ * ϕ * (u_threshold**(1/m + 1) + U**(1/m + 1))**(m/(m + 1))"
    ]
   },
   {

--- a/icepack/models/friction.py
+++ b/icepack/models/friction.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2019 by Daniel Shapero <shapero@uw.edu>
+# Copyright (C) 2017-2020 by Daniel Shapero <shapero@uw.edu>
 #
 # This file is part of icepack.
 #

--- a/icepack/models/friction.py
+++ b/icepack/models/friction.py
@@ -11,7 +11,7 @@
 # icepack source directory or at <http://www.gnu.org/licenses/>.
 
 import firedrake
-from firedrake import inner, dx, ds, sqrt
+from firedrake import inner, sqrt
 from icepack.constants import weertman_sliding_law as m
 from icepack import utilities
 
@@ -34,10 +34,10 @@ def bed_friction(u, C):
     .. math::
        \tau(u, C) = -C|u|^{1/m - 1}u
     """
-    return -m/(m + 1) * inner(tau(u, C), u) * dx
+    return -m/(m + 1) * inner(tau(u, C), u)
 
 
-def side_friction(u, h, Cs=firedrake.Constant(0), side_wall_ids=()):
+def side_friction(u, h, Cs=firedrake.Constant(0)):
     r"""Return the side wall friction part of the action functional
 
     The component of the action functional due to friction along the side
@@ -54,11 +54,10 @@ def side_friction(u, h, Cs=firedrake.Constant(0), side_wall_ids=()):
     mesh = u.ufl_domain()
     ν = firedrake.FacetNormal(mesh)
     u_t = u - inner(u, ν) * ν
-    ds_side_walls = ds(domain=mesh, subdomain_id=tuple(side_wall_ids))
-    return -m/(m + 1) * h * inner(tau(u_t, Cs), u_t) * ds_side_walls
+    return -m/(m + 1) * h * inner(tau(u_t, Cs), u_t)
 
 
-def normal_flow_penalty(u, scale=1.0, exponent=None, side_wall_ids=()):
+def normal_flow_penalty(u, scale=1.0, exponent=None):
     r"""Return the penalty for flow normal to the domain boundary
 
     For problems where a glacier flows along some boundary, e.g. a fjord
@@ -73,4 +72,4 @@ def normal_flow_penalty(u, scale=1.0, exponent=None, side_wall_ids=()):
     d = u.ufl_function_space().ufl_element().degree()
     exponent = d + 1 if exponent is None else exponent
     penalty = scale * (L / δx)**exponent
-    return 0.5 * penalty * inner(u, ν)**2 * ds(tuple(side_wall_ids))
+    return 0.5 * penalty * inner(u, ν)**2

--- a/icepack/models/friction.py
+++ b/icepack/models/friction.py
@@ -16,7 +16,7 @@ from icepack.constants import weertman_sliding_law as m
 from icepack import utilities
 
 
-def tau(u, C):
+def friction_stress(u, C):
     r"""Compute the shear stress for a given sliding velocity"""
     return -C * sqrt(inner(u, u))**(1/m - 1) * u
 
@@ -34,7 +34,8 @@ def bed_friction(u, C):
     .. math::
        \tau(u, C) = -C|u|^{1/m - 1}u
     """
-    return -m/(m + 1) * inner(tau(u, C), u)
+    τ = friction_stress(u, C)
+    return -m/(m + 1) * inner(τ, u)
 
 
 def side_friction(u, h, Cs=firedrake.Constant(0)):
@@ -54,7 +55,8 @@ def side_friction(u, h, Cs=firedrake.Constant(0)):
     mesh = u.ufl_domain()
     ν = firedrake.FacetNormal(mesh)
     u_t = u - inner(u, ν) * ν
-    return -m/(m + 1) * h * inner(tau(u_t, Cs), u_t)
+    τ = friction_stress(u_t, Cs)
+    return -m/(m + 1) * h * inner(τ, u_t)
 
 
 def normal_flow_penalty(u, scale=1.0, exponent=None):

--- a/icepack/models/viscosity.py
+++ b/icepack/models/viscosity.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2019 by Daniel Shapero <shapero@uw.edu>
+# Copyright (C) 2017-2020 by Daniel Shapero <shapero@uw.edu>
 #
 # This file is part of icepack.
 #
@@ -19,7 +19,7 @@ Several flow models all have essentially the same viscous part.
 
 import numpy as np
 import firedrake
-from firedrake import grad, dx, sqrt, Identity, inner, sym, tr as trace
+from firedrake import grad, sqrt, Identity, inner, sym, tr as trace
 from icepack.constants import year, ideal_gas as R, glen_flow_law as n
 
 transition_temperature = 263.15      # K
@@ -121,4 +121,4 @@ def viscosity_depth_averaged(u, h, A):
     -------
     firedrake.Form
     """
-    return n/(n + 1) * h * inner(M(ε(u), A), ε(u)) * dx
+    return n/(n + 1) * h * inner(M(ε(u), A), ε(u))

--- a/test/ice_shelf_test.py
+++ b/test/ice_shelf_test.py
@@ -93,7 +93,7 @@ def test_diagnostic_solver_convergence():
 def test_diagnostic_solver_parameterization():
     # Define a new viscosity functional, parameterized in terms of the
     # rheology `B` instead of the fluidity `A`
-    from firedrake import inner, grad, sym, dx, tr as trace, Identity, sqrt
+    from firedrake import inner, grad, sym, tr as trace, Identity, sqrt
 
     def M(ε, B):
         I = Identity(2)
@@ -106,7 +106,7 @@ def test_diagnostic_solver_parameterization():
         return sym(grad(u))
 
     def viscosity(u, h, B):
-        return n/(n + 1) * h * inner(M(ε(u), B), ε(u)) * dx
+        return n/(n + 1) * h * inner(M(ε(u), B), ε(u))
 
     # Make a model object with our new viscosity functional
     ice_shelf = icepack.models.IceShelf(viscosity=viscosity)


### PR DESCRIPTION
Resolves #30 and removes a whole mess of repeated code in the hybrid model. For example the kernel of the basal friction part of the action is the same for both the hybrid model and for the shallow stream equations, but the measure is different -- `dx_b` for the hybrid model and `dx` for shallow stream. Before, these had to be two different functions, whereas now they're the same.

With the old way of doing things, a user could change what part of the domain a component of an action functional was integrated over. That will no longer be possible with this patch but I think that's for the best -- a change that drastic warrants an entirely new model.

This patch doesn't quite make the improvements I was hoping for with the damage mechanics model, but it cleans things up so I think it's still worth it.