### PR TITLE
move compute surface function

### DIFF
--- a/demo/03-synthetic-ice-stream.ipynb
+++ b/demo/03-synthetic-ice-stream.ipynb
@@ -302,7 +302,7 @@
     "\n",
     "for k in range(num_timesteps + 1):\n",
     "    h = ice_stream_weertman.prognostic_solve(δt, h0=h, a=a, u=u, h_inflow=h0)\n",
-    "    s = ice_stream_weertman.compute_surface(h=h, b=b)\n",
+    "    s = icepack.compute_surface(h=h, b=b)\n",
     "    u = ice_stream_weertman.diagnostic_solve(u0=u, h=h, s=s, A=A, C=C, **opts)\n",
     "    print('.' if k * δt % 10 == 0 else '', end='')"
    ]
@@ -311,7 +311,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now some plots of the results:"
+    "Notice that we have one extra step in the middle of the simulation loop.\n",
+    "For ice shelves, all we had to do was (1) update the thickness according to the prognostic equation and then (2) compute the new ice velocity corresponding to this thickness.\n",
+    "Since ice shelves are floating, we can calculate the surface elevation as a function of the ice thickness knowing the densities of ice and ocean water, and this is baked into the formulation of the problem.\n",
+    "Ice streams, on the other hand, can be grounded or floating.\n",
+    "After we update the ice thickness, we need to explicitly calculate a new surface elevation in a way that accounts for whether the ice is floating or grounded, and that's what the function `icepack.compute_surface` does.\n",
+    "Let's see what the results look like."
    ]
   },
   {
@@ -617,7 +622,7 @@
     "def run_simulation(model, h, s, u, **kwargs):\n",
     "    for k in range(num_timesteps + 1):\n",
     "        h = model.prognostic_solve(δt, h0=h, a=a, u=u, h_inflow=h0)\n",
-    "        s = model.compute_surface(h=h, b=b)\n",
+    "        s = icepack.compute_surface(h=h, b=b)\n",
     "        u = model.diagnostic_solve(u0=u, h=h, s=s, **kwargs)\n",
     "        print('.' if k * δt % 10 == 0 else '', end='')\n",
     "        \n",

--- a/demo/05-hybrid-ice-stream.ipynb
+++ b/demo/05-hybrid-ice-stream.ipynb
@@ -255,7 +255,7 @@
     "\n",
     "for k in range(num_timesteps + 1):\n",
     "    h = model.prognostic_solve(δt, h0=h, a=a, u=u, h_inflow=h0)\n",
-    "    s = model.compute_surface(h=h, b=b)\n",
+    "    s = icepack.compute_surface(h=h, b=b)\n",
     "    u = model.diagnostic_solve(u0=u, h=h, s=s, A=A, C=C, **opts)\n",
     "    print('.' if k * δt % 10 == 0 else '', end='')"
    ]

--- a/icepack/__init__.py
+++ b/icepack/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2019 by Daniel Shapero <shapero@uw.edu>
+# Copyright (C) 2017-2020 by Daniel Shapero <shapero@uw.edu>
 #
 # This file is part of icepack.
 #
@@ -12,7 +12,7 @@
 
 from icepack.norms import norm
 from icepack.interpolate import interpolate
-from icepack.utilities import depth_average, lift3d
+from icepack.utilities import depth_average, lift3d, compute_surface
 from icepack.models.viscosity import rate_factor
 import icepack.meshing
 import icepack.datasets

--- a/icepack/models/hybrid.py
+++ b/icepack/models/hybrid.py
@@ -10,6 +10,7 @@
 # The full text of the license can be found in the file LICENSE in the
 # icepack source directory or at <http://www.gnu.org/licenses/>.
 
+import warnings
 import functools
 import sympy
 import firedrake
@@ -23,7 +24,8 @@ from icepack.constants import (ice_density as ρ_I, water_density as ρ_W,
                                glen_flow_law as n, weertman_sliding_law as m,
                                gravity as g)
 from icepack.utilities import (facet_normal_2, grad_2, diameter,
-                               add_kwarg_wrapper)
+                               add_kwarg_wrapper,
+                               compute_surface as _compute_surface)
 
 def gravity(u, h, s):
     r"""Return the gravitational part of the ice stream action functional
@@ -285,17 +287,8 @@ class HybridModel(object):
         return self.mass_transport.solve(dt, h0=h0, a=a, u=u, **kwargs)
 
     def compute_surface(self, h, b):
-        r"""Return the ice surface elevation consistent with a given
-        thickness and bathymetry
-
-        If the bathymetry beneath a tidewater glacier is too low, the ice
-        will go afloat. The surface elevation of a floating ice shelf is
-
-        .. math::
-           s = (1 - \rho_I / \rho_W)h,
-
-        provided everything is in hydrostatic balance.
-        """
-        Q = h.ufl_function_space()
-        s_expr = firedrake.max_value(h + b, (1 - ρ_I / ρ_W) * h)
-        return firedrake.interpolate(s_expr, Q)
+        warnings.warn('Compute surface moved from member function of models to'
+                      ' icepack module; call `icepack.compute_surface` instead'
+                      ' of e.g. `ice_stream.compute_surface`',
+                      DeprecationWarning)
+        return _compute_surface(h, b)

--- a/icepack/models/ice_stream.py
+++ b/icepack/models/ice_stream.py
@@ -10,6 +10,7 @@
 # The full text of the license can be found in the file LICENSE in the
 # icepack source directory or at <http://www.gnu.org/licenses/>.
 
+import warnings
 import firedrake
 from firedrake import inner, grad, dx, ds
 from icepack.constants import (ice_density as ρ_I, water_density as ρ_W,
@@ -19,7 +20,8 @@ from icepack.models.friction import (bed_friction, side_friction,
                                      normal_flow_penalty)
 from icepack.models.mass_transport import LaxWendroff
 from icepack.optimization import newton_search
-from icepack.utilities import add_kwarg_wrapper
+from icepack.utilities import (add_kwarg_wrapper,
+                               compute_surface as _compute_surface)
 
 
 def gravity(u, h, s):
@@ -197,17 +199,8 @@ class IceStream(object):
         return self.mass_transport.solve(dt, h0=h0, a=a, u=u, h_inflow=h_inflow)
 
     def compute_surface(self, h, b):
-        r"""Return the ice surface elevation consistent with a given
-        thickness and bathymetry
-
-        If the bathymetry beneath a tidewater glacier is too low, the ice
-        will go afloat. The surface elevation of a floating ice shelf is
-
-        .. math::
-           s = (1 - \rho_I / \rho_W)h,
-
-        provided everything is in hydrostatic balance.
-        """
-        Q = h.ufl_function_space()
-        s_expr = firedrake.max_value(h + b, (1 - ρ_I / ρ_W) * h)
-        return firedrake.interpolate(s_expr, Q)
+        warnings.warn('Compute surface moved from member function of models to'
+                      ' icepack module; call `icepack.compute_surface` instead'
+                      ' of e.g. `ice_stream.compute_surface`',
+                      DeprecationWarning)
+        return _compute_surface(h, b)

--- a/test/ice_stream_test.py
+++ b/test/ice_stream_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2019 by Daniel Shapero <shapero@uw.edu>
+# Copyright (C) 2017-2020 by Daniel Shapero <shapero@uw.edu>
 #
 # This file is part of icepack.
 #
@@ -187,6 +187,6 @@ def test_computing_surface():
     b = interpolate(firedrake.Constant(b0), Q)
 
     ice_stream = icepack.models.IceStream()
-    s = ice_stream.compute_surface(h=h, b=b)
+    s = icepack.compute_surface(h=h, b=b)
     x0, y0 = Lx/2, Ly/2
     assert abs(s((x0, y0)) - (1 - ρ_I / ρ_W) * h((x0, y0))) < 1e-8

--- a/test/mass_transport_test.py
+++ b/test/mass_transport_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2019 by Daniel Shapero <shapero@uw.edu>
+# Copyright (C) 2017-2020 by Daniel Shapero <shapero@uw.edu>
 #
 # This file is part of icepack.
 #
@@ -176,7 +176,7 @@ def test_ice_stream_prognostic_solve():
 
     for k in range(num_timesteps):
         h = model.prognostic_solve(dt, h0=h, a=a, u=u, h_inflow=h_inflow)
-        s = model.compute_surface(h=h, b=b)
+        s = icepack.compute_surface(h=h, b=b)
         u = model.diagnostic_solve(u0=u, h=h, s=s, C=C, A=A, **opts)
 
     assert icepack.norm(h, norm_type='Linfty') < np.inf
@@ -233,7 +233,7 @@ def test_hybrid_prognostic_solve():
 
     for k in range(num_timesteps):
         h = model.prognostic_solve(dt, h0=h, a=a, u=u, h_inflow=h_inflow)
-        s = model.compute_surface(h=h, b=b)
+        s = icepack.compute_surface(h=h, b=b)
         u = model.diagnostic_solve(u0=u, h=h, s=s, C=C, A=A, **opts)
 
     assert icepack.norm(h, norm_type='Linfty') < np.inf


### PR DESCRIPTION
The `compute_surface` function lives in two places, the ice stream model and the hybrid model. This patch lifts them into the `icepack` module which cuts some repeated code. Calling it through the model objects now gives a deprecation warning.