### PR TITLE
New convergence criterion for inverse solve

### DIFF
--- a/demo/04-ice-shelf-inverse.ipynb
+++ b/demo/04-ice-shelf-inverse.ipynb
@@ -253,7 +253,7 @@
     "θ = firedrake.Function(Q)\n",
     "\n",
     "model = icepack.models.IceShelf(viscosity=viscosity)\n",
-    "opts = {'dirichlet_ids': [2, 4, 5, 6, 7, 8, 9], 'tolerance': 1e-6}\n",
+    "opts = {'dirichlet_ids': [2, 4, 5, 6, 7, 8, 9]}\n",
     "solver = icepack.solvers.FlowSolver(model, **opts)\n",
     "u = solver.diagnostic_solve(u=u_obs, h=h, θ=θ)"
    ]
@@ -349,9 +349,19 @@
     "Using this class should save you from worrying about too many low-level details, but still provide a good amount of flexibility and transparency.\n",
     "\n",
     "As a convenience, the inverse solver can take in a function that it will call at the end of every iteration.\n",
-    "For this demonstration, we'll have it print out the values of the misfit and regularization functionals.\n",
-    "You could also, say, make a plot of the state and parameter guess at every iteration to make a movie of how the algorithm progresses.\n",
-    "In programming parlance, a function like this is referred to as a *callback*."
+    "For this demonstration, we'll have it print out the values of the misfit and regularization functionals and the expected decrease in the sum of those two functionals.\n",
+    "The expected decrease in $J$ can be calculated as\n",
+    "\n",
+    "$$\\Delta = \\langle dJ, q\\rangle,$$\n",
+    "\n",
+    "where $dJ$ is the gradient of $J$ and $q$ is the search direction.\n",
+    "The expected decrease should be negative on every step -- after all, we're trying to find a minimizer of $J$.\n",
+    "If the expected decrease becomes positive, that suggests that we've found a local minimum and no more improvement is possible.\n",
+    "This is an important number to watch because it can tell you whether or not it's worthwhile to take more iterations of the solver.\n",
+    "\n",
+    "We've also passed some extra arguments to `assemble` to specify the quadrature rule for calculating the expected decrease.\n",
+    "By default, the assembly routine will be very conservative and use a much more accurate quadrature rule than we really need.\n",
+    "So this step isn't strictly necessary, it's just good practice."
    ]
   },
   {
@@ -360,17 +370,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "params = {'quadrature_degree': model.quadrature_degree(u=u, h=h, θ=θ)}\n",
+    "\n",
     "area = firedrake.assemble(firedrake.Constant(1) * dx(mesh))\n",
     "def callback(solver):\n",
-    "    E = firedrake.assemble(solver.objective)\n",
-    "    R = firedrake.assemble(solver.regularization)\n",
-    "    print('{:g}, {:g}'.format(E/area, R/area))"
+    "    dJ = solver.gradient\n",
+    "    q = solver.search_direction\n",
+    "    dJ_dq = firedrake.action(dJ, q)\n",
+    "    Δ = firedrake.assemble(dJ_dq, form_compiler_parameters=params) / area\n",
+    "\n",
+    "    E = firedrake.assemble(solver.objective) / area\n",
+    "    R = firedrake.assemble(solver.regularization) / area\n",
+    "    print('{:g}, {:g}, {:g}'.format(E, R, Δ))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You could also, say, make a plot of the state and parameter guess at every iteration to make a movie of how the algorithm progresses.\n",
+    "In programming parlance, a function like this is referred to as a *callback*.\n",
+    "\n",
     "To create the solver object, we only need to give it a problem and optionally the callback function."
    ]
   },
@@ -400,8 +420,8 @@
    "outputs": [],
    "source": [
     "fig, axes = subplots()\n",
-    "contours = icepack.plot.tricontourf(solver.search_direction, 20, alpha=0.6,\n",
-    "                                    cmap='RdBu', axes=axes)\n",
+    "ϕ = solver.search_direction\n",
+    "contours = icepack.plot.tricontourf(ϕ, 20, alpha=0.6, cmap='RdBu', axes=axes)\n",
     "fig.colorbar(contours)\n",
     "plt.show(fig)"
    ]
@@ -416,7 +436,10 @@
     "Computing the search direction like this is time-consuming, but results in far fewer iterations, so it's a net win.\n",
     "\n",
     "The solve method takes in a relative convergence tolerance, an absolute tolerance, and a maximum number of iterations, and it returns the total number of iterations necessary to achieve the given tolerances.\n",
-    "In our case, we'll stop once the relative decrease in the objective function from one iteration to the next is less than 1/200.\n",
+    "In our case, we'll stop once either (1) the relative decrease in the objective function from one iteration to the next is less than 1/200 or (2) the expected relative decrease in the objective is less than 1/1,000,000.\n",
+    "The relevant tolerances for these are respectively `rtol` and `etol`.\n",
+    "There's also an absolute stopping tolerance `atol`, which we won't use this time.\n",
+    "Absolute stopping tolerances are good for certain statistical problems where you know a priori how good of a fit to the data to expect.\n",
     "\n",
     "The algorithm takes a while to run.\n",
     "Now would be the time to put on a fresh pot of coffee."
@@ -430,6 +453,7 @@
    "source": [
     "iterations = solver.solve(\n",
     "    rtol=5e-3,\n",
+    "    etol=1e-6,\n",
     "    atol=0.0,\n",
     "    max_iterations=30\n",
     ")"
@@ -440,6 +464,7 @@
    "metadata": {},
    "source": [
     "The algorithm converges in just a few iterations because of how good a search direction we get from using the Gauss-Newton approximation.\n",
+    "It's also worth observing how quickly the magnitude of the expected decrease in the objective functional gets reduced on every iteration -- usually by at least a factor of four every time.\n",
     "Other methods like gradient descent take many more iterations to reach the same agreement with the data."
    ]
   },


### PR DESCRIPTION
This patch fixes some potential problems when the inverse solver is very near or at a local minimum:

* The `_bracket` function can enter an infinite loop if the solver has reached a local minimum.
* The solver does nothing to check whether the Newton decrement is actually negative.

These have both been fixed and I've added a new convergence criterion based on the Newton decrement.
I've also updated the inverse demo to suggest that users print out the Newton decrement as part of the solver callback.
This can help as a smoke test for potential convergence failure or really bad conditioning.