### PR TITLE
Make warnings louder

### DIFF
--- a/icepack/models/damage_transport.py
+++ b/icepack/models/damage_transport.py
@@ -17,6 +17,7 @@ This module contains a solver for the conservative advection equation that
 describes the evolution of ice damage (Albrecht and Levermann 2014).
 """
 
+import warnings
 import numpy as np
 import firedrake
 from firedrake import (inner, grad, div, dx, ds, dS, sqrt, sym,
@@ -101,6 +102,9 @@ class DamageTransport(object):
         D : firedrake.Function
             Ice damage at `t + dt`
         """
+        warnings.warn('Solving methods have moved to the DamageSolver class, '
+                      'this method will be removed in future versions.',
+                      FutureWarning)
 
         D_inflow = D_inflow if D_inflow is not None else D0
         Q = D0.function_space()

--- a/icepack/models/heat_transport.py
+++ b/icepack/models/heat_transport.py
@@ -152,7 +152,7 @@ class HeatTransport3D(object):
         r"""Propagate the energy density forward by one timestep"""
         warnings.warn('Solving methods have moved to the HeatTransportSolver '
                       'class, this method will be removed in future versions.',
-                      DeprecationWarning)
+                      FutureWarning)
 
         E_inflow = E_inflow if E_inflow is not None else E0
         E_surface = E_surface if E_surface is not None else E0

--- a/icepack/models/hybrid.py
+++ b/icepack/models/hybrid.py
@@ -271,7 +271,7 @@ class HybridModel(object):
         """
         warnings.warn('Solving methods have moved to the FlowSolver class, '
                       'this method will be removed in future versions.',
-                      DeprecationWarning)
+                      FutureWarning)
 
         u = u0.copy(deepcopy=True)
 
@@ -298,5 +298,5 @@ class HybridModel(object):
         warnings.warn('Compute surface moved from member function of models to'
                       ' icepack module; call `icepack.compute_surface` instead'
                       ' of e.g. `ice_stream.compute_surface`',
-                      DeprecationWarning)
+                      FutureWarning)
         return _compute_surface(h, b)

--- a/icepack/models/ice_shelf.py
+++ b/icepack/models/ice_shelf.py
@@ -185,7 +185,7 @@ class IceShelf(object):
         """
         warnings.warn('Solving methods have moved to the FlowSolver class, '
                       'this method will be removed in future versions.',
-                      DeprecationWarning)
+                      FutureWarning)
 
         u = u0.copy(deepcopy=True)
 

--- a/icepack/models/ice_stream.py
+++ b/icepack/models/ice_stream.py
@@ -179,7 +179,7 @@ class IceStream(object):
         """
         warnings.warn('Solving methods have moved to the FlowSolver class, '
                       'this method will be removed in future versions.',
-                      DeprecationWarning)
+                      FutureWarning)
 
         u = u0.copy(deepcopy=True)
 
@@ -210,5 +210,5 @@ class IceStream(object):
         warnings.warn('Compute surface moved from member function of models to'
                       ' icepack module; call `icepack.compute_surface` instead'
                       ' of e.g. `ice_stream.compute_surface`',
-                      DeprecationWarning)
+                      FutureWarning)
         return _compute_surface(h, b)

--- a/icepack/models/mass_transport.py
+++ b/icepack/models/mass_transport.py
@@ -109,7 +109,7 @@ class ImplicitEuler(MassTransport):
         """
         warnings.warn('Solving methods have moved to the FlowSolver class, '
                       'this method will be removed in future versions.',
-                      DeprecationWarning)
+                      FutureWarning)
 
         grad, ds = self.grad, self.ds
 
@@ -168,7 +168,7 @@ class LaxWendroff(MassTransport):
         """
         warnings.warn('Solving methods have moved to the FlowSolver class, '
                       'this method will be removed in future versions.',
-                      DeprecationWarning)
+                      FutureWarning)
 
         grad, div, ds = self.grad, self.div, self.ds
 

--- a/icepack/models/shallow_ice.py
+++ b/icepack/models/shallow_ice.py
@@ -178,7 +178,7 @@ class ShallowIce(object):
         """
         warnings.warn('Solving methods have moved to the FlowSolver class, '
                       'this method will be removed in future versions.',
-                      DeprecationWarning)
+                      FutureWarning)
 
         u = u0.copy(deepcopy=True)
         action = self.action(u=u, h=h, s=s, A=A, **kwargs)

--- a/icepack/utilities.py
+++ b/icepack/utilities.py
@@ -19,6 +19,7 @@ import firedrake
 from firedrake import sqrt, tr, det
 from icepack.constants import ice_density as ρ_I, water_density as ρ_W
 
+
 default_solver_parameters = {
     'ksp_type': 'preonly',
     'pc_type': 'lu',


### PR DESCRIPTION
By default, Python [doesn't show DeprecationWarning](https://docs.python.org/3/library/warnings.html#default-warning-filter). The argument is that these are often buried deep down in dependencies of dependencies, and end users shouldn't get a bunch of cryptic terminal output for something that's a developer's job to fix. You can view them by calling a script with `python3 -Wd`, which was a new one on me. We need users to know if they're calling functionality that's soon to be removed, so this patch changes all deprecation warnings to FutureWarning, which is actually visible.