### PR TITLE
Revert back to bespoke optimization solver

### DIFF
--- a/icepack/models/hybrid.py
+++ b/icepack/models/hybrid.py
@@ -14,29 +14,18 @@ import warnings
 import functools
 import sympy
 import firedrake
-from firedrake import (
-    inner, outer, sym, Identity, tr as trace, sqrt, grad, dx, ds, ds_b, ds_v
-)
-from icepack.models.friction import (
-    bed_friction, side_friction, normal_flow_penalty
-)
+from firedrake import (inner, outer, sym, Identity, tr as trace, sqrt,
+                       grad, dx, ds, ds_b, ds_v)
+from icepack.models.friction import (bed_friction, side_friction,
+                                     normal_flow_penalty)
 from icepack.models.mass_transport import LaxWendroff, Continuity
-from icepack.constants import (
-    ice_density as ρ_I,
-    water_density as ρ_W,
-    glen_flow_law as n,
-    weertman_sliding_law as m,
-    gravity as g
-)
-from icepack.utilities import (
-    grad_2,
-    facet_normal_2,
-    diameter,
-    add_kwarg_wrapper,
-    get_kwargs_alt,
-    default_solver_parameters,
-    compute_surface as _compute_surface
-)
+from icepack.optimization import MinimizationProblem, NewtonSolver
+from icepack.constants import (ice_density as ρ_I, water_density as ρ_W,
+                               glen_flow_law as n, weertman_sliding_law as m,
+                               gravity as g)
+from icepack.utilities import (facet_normal_2, grad_2, diameter,
+                               add_kwarg_wrapper, get_kwargs_alt,
+                               compute_surface as _compute_surface)
 
 def gravity(**kwargs):
     r"""Return the gravitational part of the ice stream action functional
@@ -235,9 +224,16 @@ class HybridModel(object):
         ds_t = ds_v(domain=mesh, subdomain_id=ice_front_ids, metadata=metadata)
         terminus = self.terminus(**kwargs) * ds_t
 
-        return (
-            viscosity + friction + side_friction - gravity - terminus + penalty
-        )
+        return (viscosity + friction + side_friction
+                - gravity - terminus + penalty)
+
+    def scale(self, **kwargs):
+        r"""Return the positive, convex part of the action functional
+
+        The positive part of the action functional is used as a dimensional
+        scale to determine when to terminate an optimization algorithm.
+        """
+        return (self.viscosity(**kwargs) * dx + self.friction(**kwargs) * ds_b)
 
     def quadrature_degree(self, **kwargs):
         r"""Return the quadrature degree necessary to integrate the action
@@ -297,18 +293,16 @@ class HybridModel(object):
         side_wall_ids = kwargs.get('side_wall_ids', [])
         kwargs['side_wall_ids'] = side_wall_ids
         kwargs['ice_front_ids'] = list(
-            set(boundary_ids) - set(dirichlet_ids) - set(side_wall_ids)
-        )
-        V = u.function_space()
-        bcs = firedrake.DirichletBC(V, u, dirichlet_ids)
+            set(boundary_ids) - set(dirichlet_ids) - set(side_wall_ids))
+        bcs = firedrake.DirichletBC(
+            u.function_space(), firedrake.as_vector((0, 0)), dirichlet_ids)
         params = {'quadrature_degree': self.quadrature_degree(u=u, h=h, **kwargs)}
 
-        F = firedrake.derivative(self.action(u=u, h=h, s=s, **kwargs), u)
-        firedrake.solve(
-            F == 0, u, bcs,
-            form_compiler_parameters=params,
-            solver_parameters=default_solver_parameters
-        )
+        action = self.action(u=u, h=h, s=s, **kwargs)
+        scale = self.scale(u=u, h=h, s=s, **kwargs)
+        problem = MinimizationProblem(action, scale, u, bcs, params)
+        solver = NewtonSolver(problem, tol)
+        solver.solve()
         return u
 
     def prognostic_solve(self, dt, h0, a, u, **kwargs):

--- a/icepack/models/shallow_ice.py
+++ b/icepack/models/shallow_ice.py
@@ -129,6 +129,14 @@ class ShallowIce(object):
         penalty = self.penalty(**kwargs) * dx
         return mass + gravity + penalty
 
+    def scale(self, **kwargs):
+        r"""Return the positive, convex part of the action functional
+
+        The positive part of the action functional is used as a dimensional
+        scale to determine when to terminate an optimization algorithm.
+        """
+        return (self.mass(**kwargs) + self.penalty(**kwargs)) * dx
+
     def quadrature_degree(self, **kwargs):
         r"""Return the quadrature degree necessary to integrate the action
         functional accurately"""

--- a/icepack/optimization.py
+++ b/icepack/optimization.py
@@ -1,0 +1,145 @@
+# Copyright (C) 2017-2020 by Daniel Shapero <shapero@uw.edu>
+#
+# This file is part of icepack.
+#
+# icepack is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# The full text of the license can be found in the file LICENSE in the
+# icepack source directory or at <http://www.gnu.org/licenses/>.
+
+import firedrake
+from .utilities import default_solver_parameters
+
+class MinimizationProblem(object):
+    def __init__(self, E, S, u, bcs, form_compiler_parameters, **kwargs):
+        r"""Nonlinear optimization problem argmin E(u).
+
+        Parameters
+        ----------
+        E : firedrake.Form
+            The functional to be minimized
+        S : firedrake.Form
+            A positive functional measure the scale of the solution
+        u : firedrake.Function
+            Initial guess for the minimizer
+        bcs : firedrake.DirichletBC
+            any essential boundary conditions for the solution
+        """
+        self.E = E
+        self.S = S
+        self.u = u
+        self.bcs = bcs
+        self.form_compiler_parameters = form_compiler_parameters
+
+    def assemble(self, *args, **kwargs):
+        kwargs['form_compiler_parameters'] = self.form_compiler_parameters
+        return firedrake.assemble(*args, **kwargs)
+
+
+class NewtonSolver(object):
+    def __init__(self, problem, tolerance, solver_parameters=None, **kwargs):
+        r"""Solve a MinimizationProblem using Newton's method with backtracking
+        line search
+
+        Parameters
+        ----------
+        problem : MinimizationProblem
+            The particular problem instance to solve
+        tolerance : float
+            dimensionless tolerance for when to stop iterating, measured with
+            with respect to the problem's scale functional
+        solver_parameters : dict (optional)
+            Linear solve parameters for computing the search direction
+        armijo : float (optional)
+            Parameter in the Armijo condition for line search; defaults to
+            1e-4, see Nocedal and Wright
+        contraction : float (optional)
+            shrinking factor for backtracking line search; defaults to .5
+        max_iterations : int (optional)
+            maximum number of outer-level Newton iterations; defaults to 50
+        """
+        self.problem = problem
+        self.tolerance = tolerance
+        if solver_parameters is None:
+            solver_parameters = default_solver_parameters
+
+        self.armijo = kwargs.pop('armijo', 1e-4)
+        self.contraction = kwargs.pop('contraction', 0.5)
+        self.max_iterations = kwargs.pop('max_iterations', 50)
+
+        u = self.problem.u
+        V = u.function_space()
+        v = firedrake.Function(V)
+        self.v = v
+
+        E = self.problem.E
+        self.F = firedrake.derivative(E, u)
+        self.J = firedrake.derivative(self.F, u)
+        self.dE_dv = firedrake.action(self.F, v)
+
+        bcs = None
+        if self.problem.bcs:
+            bcs = firedrake.homogenize(self.problem.bcs)
+        problem = firedrake.LinearVariationalProblem(
+            self.J, -self.F, v, bcs, constant_jacobian=False,
+            form_compiler_parameters=self.problem.form_compiler_parameters
+        )
+        self.search_direction_solver = firedrake.LinearVariationalSolver(
+            problem, solver_parameters=solver_parameters
+        )
+
+        self.search_direction_solver.solve()
+        self.t = firedrake.Constant(0.)
+        self.iteration = 0
+
+    def reinit(self):
+        self.search_direction_solver.solve()
+        self.t.assign(0.)
+        self.iteration = 0
+
+    def step(self):
+        r"""Perform a backtracking line search for the next value of the
+        solution and compute the search direction for the next step"""
+        E = self.problem.E
+        u = self.problem.u
+        v = self.v
+        t = self.t
+
+        t.assign(1.)
+        E_0 = self.problem.assemble(E)
+        slope = self.problem.assemble(self.dE_dv)
+        if slope > 0:
+            raise firedrake.ConvergenceError(
+                'Minimization solver has invalid search direction. This is '
+                'likely due to a negative thickness or friction coefficient or'
+                'otherwise physically invalid input data.'
+            )
+
+        E_t = firedrake.replace(E, {u: u + t * v})
+
+        armijo = self.armijo
+        contraction = self.contraction
+        while self.problem.assemble(E_t) > E_0 + armijo * float(t) * slope:
+            t.assign(t * contraction)
+
+        u.assign(u + t * v)
+        self.search_direction_solver.solve()
+        self.iteration += 1
+
+    def solve(self):
+        r"""Step the Newton iteration until convergence"""
+        self.reinit()
+
+        dE_dv = self.dE_dv
+        S = self.problem.S
+        _assemble = self.problem.assemble
+        while abs(_assemble(dE_dv)) > self.tolerance * _assemble(S):
+            self.step()
+            if self.iteration >= self.max_iterations:
+                raise firedrake.ConvergenceError(
+                    'Newton search did not converge after {} iterations!'
+                    .format(self.max_iterations)
+                )

--- a/test/ice_shelf_test.py
+++ b/test/ice_shelf_test.py
@@ -10,12 +10,10 @@
 # The full text of the license can be found in the file LICENSE in the
 # icepack source directory or at <http://www.gnu.org/licenses/>.
 
-import pytest
 import numpy as np
 import firedrake
 from firedrake import interpolate, as_vector
 import icepack
-from icepack import norm
 from icepack.constants import (
     ice_density as ρ_I, water_density as ρ_W, gravity as g, glen_flow_law as n
 )
@@ -48,6 +46,10 @@ def perturb_u(x, y):
     return 60 * q * (px - 0.5)
 
 
+def norm(v):
+    return icepack.norm(v, norm_type='H1')
+
+
 # Check that the diagnostic solver converges with the expected rate as the
 # mesh is refined using an exact solution of the ice shelf model.
 def test_diagnostic_solver_convergence():
@@ -77,8 +79,10 @@ def test_diagnostic_solver_convergence():
                 thickness=h,
                 fluidity=A
             )
-            error.append(norm(u_exact - u, 'H1') / norm(u_exact, 'H1'))
+            error.append(norm(u_exact - u) / norm(u_exact))
             delta_x.append(Lx / N)
+
+            print(delta_x[-1], error[-1])
 
         # Fit the error curve and check that the convergence rate is what we
         # expect
@@ -138,8 +142,10 @@ def test_diagnostic_solver_parameterization():
             thickness=h,
             rheology=B
         )
-        error.append(norm(u_exact - u, 'H1') / norm(u_exact, 'H1'))
+        error.append(norm(u_exact - u) / norm(u_exact))
         delta_x.append(Lx / N)
+
+        print(delta_x[-1], error[-1])
 
     log_delta_x = np.log2(np.array(delta_x))
     log_error = np.log2(np.array(error))
@@ -171,7 +177,7 @@ def test_diagnostic_solver_side_friction():
     # stress is 10 kPa.
     from icepack.constants import weertman_sliding_law as m
     τ = 0.01
-    u_max = norm(u_initial, 'Linfty')
+    u_max = icepack.norm(u_initial, norm_type='Linfty')
     Cs = firedrake.Constant(τ * u_max**(-1/m))
 
     solver = icepack.solvers.FlowSolver(model, **opts)
@@ -184,179 +190,3 @@ def test_diagnostic_solver_side_friction():
     u = solver.diagnostic_solve(**fields)
 
     assert icepack.norm(u) < icepack.norm(u_initial)
-
-
-# Try using different options for the diagnostic solve
-def test_diagnostic_solver_options():
-    model = icepack.models.IceShelf()
-    nx, ny = 32, 32
-    mesh = firedrake.RectangleMesh(nx, ny, Lx, Ly)
-
-    degree = 2
-    V = firedrake.VectorFunctionSpace(mesh, 'CG', degree)
-    Q = firedrake.FunctionSpace(mesh, 'CG', degree)
-
-    x, y = firedrake.SpatialCoordinate(mesh)
-    u_initial = interpolate(as_vector((exact_u(x), 0)), V)
-    h = interpolate(h0 - dh * x / Lx, Q)
-    A = interpolate(firedrake.Constant(icepack.rate_factor(T)), Q)
-
-    from icepack.constants import weertman_sliding_law as m
-    τ = 0.01
-    u_max = norm(u_initial, 'Linfty')
-    Cs = firedrake.Constant(τ * u_max**(-1/m))
-
-    opts = {'dirichlet_ids': [1], 'side_wall_ids': [3, 4]}
-
-    from icepack.utilities import default_solver_parameters
-    direct_solver = icepack.solvers.FlowSolver(
-        model, **opts, diagnostic_solver_parameters=default_solver_parameters
-    )
-
-    iterative_parameters = {'ksp_type': 'cg', 'pc_type': 'ilu'}
-    iterative_solver = icepack.solvers.FlowSolver(
-        model, **opts, diagnostic_solver_parameters=iterative_parameters
-    )
-
-    fields = {
-        'velocity': u_initial,
-        'thickness': h,
-        'fluidity': A,
-        'side_friction': Cs
-    }
-
-    u_direct = direct_solver.diagnostic_solve(**fields)
-    u_iterative = iterative_solver.diagnostic_solve(**fields)
-
-    tol = 1 / nx ** degree
-    assert norm(u_direct - u_iterative, 'H1') < tol * norm(u_direct, 'H1')
-
-
-# Test solving the mass transport equations with a constant velocity field
-# and check that the solutions converge to the exact solution obtained from
-# the method of characteristics.
-# Test solving the coupled diagnostic/prognostic equations for an ice shelf
-# with thickness and velocity fields that are exactly insteady state.
-@pytest.mark.parametrize(
-    'prognostic_solver_parameters', [
-        icepack.utilities.default_solver_parameters,
-        {'ksp_type': 'gmres', 'pc_type': 'ilu'}
-    ]
-)
-def test_mass_transport_solver_convergence(prognostic_solver_parameters):
-    Lx, Ly = 1.0, 1.0
-    u0 = 1.0
-    h_in, dh = 1.0, 0.2
-
-    delta_x, error = [], []
-    model = icepack.models.IceShelf()
-    for N in range(24, 97, 4):
-        delta_x.append(Lx / N)
-
-        mesh = firedrake.RectangleMesh(N, N, Lx, Ly)
-        x, y = firedrake.SpatialCoordinate(mesh)
-
-        degree = 1
-        V = firedrake.VectorFunctionSpace(mesh, 'CG', degree)
-        Q = firedrake.FunctionSpace(mesh, 'CG', degree)
-        solver = icepack.solvers.FlowSolver(
-            model, prognostic_solver_parameters=prognostic_solver_parameters
-        )
-
-        h0 = interpolate(h_in - dh * x / Lx, Q)
-        a = firedrake.Function(Q)
-        u = interpolate(firedrake.as_vector((u0, 0)), V)
-        T = 0.5
-        δx = 1.0 / N
-        δt = δx / u0
-        num_timesteps = int(T / δt)
-
-        h = h0.copy(deepcopy=True)
-        for step in range(num_timesteps):
-            h = solver.prognostic_solve(
-                δt,
-                thickness=h,
-                velocity=u,
-                accumulation=a,
-                thickness_inflow=h0
-            )
-
-        z = x - u0 * num_timesteps * δt
-        h_exact = interpolate(h_in - dh/Lx * firedrake.max_value(0, z), Q)
-        error.append(norm(h - h_exact, 'L1') / norm(h_exact, 'L1'))
-
-    log_delta_x = np.log2(np.array(delta_x))
-    log_error = np.log2(np.array(error))
-    slope, intercept = np.polyfit(log_delta_x, log_error, 1)
-
-    print('log(error) ~= {:g} * log(dx) + {:g}'.format(slope, intercept))
-    assert slope > degree - 0.1
-
-
-# Test solving the coupled diagnostic/prognostic equations for an ice shelf
-# with thickness and velocity fields that are exactly insteady state.
-def test_ice_shelf_prognostic_solver():
-    ρ = ρ_I * (1 - ρ_I / ρ_W)
-
-    Lx, Ly = 20.0e3, 20.0e3
-    h0 = 500.0
-    u0 = 100.0
-    T = 254.15
-
-    model = icepack.models.IceShelf()
-    opts = {'dirichlet_ids': [1], 'side_wall_ids': [3, 4]}
-
-    delta_x, error = [], []
-    for N in range(16, 65, 4):
-        delta_x.append(Lx / N)
-
-        mesh = firedrake.RectangleMesh(N, N, Lx, Ly)
-        x, y = firedrake.SpatialCoordinate(mesh)
-
-        degree = 2
-        V = firedrake.VectorFunctionSpace(mesh, 'CG', degree)
-        Q = firedrake.FunctionSpace(mesh, 'CG', degree)
-
-        q = (n + 1) * (ρ * g * h0 * u0 / 4)**n * icepack.rate_factor(T)
-        ux = (u0**(n + 1) + q * x)**(1/(n + 1))
-
-        h = interpolate(h0 * u0 / ux, Q)
-        h_initial = h.copy(deepcopy=True)
-
-        A = firedrake.Constant(icepack.rate_factor(T))
-        a = firedrake.Constant(0)
-
-        solver = icepack.solvers.FlowSolver(model, **opts)
-        u_guess = interpolate(firedrake.as_vector((ux, 0)), V)
-        u = solver.diagnostic_solve(
-            velocity=u_guess, thickness=h, fluidity=A
-        )
-
-        final_time = 1.0
-        timestep = 2 / N
-        num_timesteps = int(final_time / timestep)
-        dt = final_time / num_timesteps
-
-        for step in range(num_timesteps):
-            h = solver.prognostic_solve(
-                dt,
-                thickness=h,
-                velocity=u,
-                accumulation=a,
-                thickness_inflow=h_initial
-            )
-
-            u = solver.diagnostic_solve(
-                velocity=u,
-                thickness=h,
-                fluidity=A
-            )
-
-        error.append(norm(h - h_initial, 'L1') / norm(h_initial, 'L1'))
-
-    log_delta_x = np.log2(np.array(delta_x))
-    log_error = np.log2(np.array(error))
-    slope, intercept = np.polyfit(log_delta_x, log_error, 1)
-
-    print('log(error) ~= {:g} * log(dx) + {:g}'.format(slope, intercept))
-    assert slope > degree - 0.05

--- a/test/ice_stream_test.py
+++ b/test/ice_stream_test.py
@@ -87,7 +87,6 @@ def test_manufactured_solution():
 import firedrake
 from firedrake import interpolate, as_vector
 import icepack
-from icepack import norm
 from icepack.constants import (
     ice_density as ρ_I,
     water_density as ρ_W,
@@ -141,6 +140,10 @@ def friction(x):
 ds = (1 + β) * ρ / ρ_I * dh
 
 
+def norm(v):
+    return icepack.norm(v, norm_type='H1')
+
+
 def test_diagnostic_solver_convergence():
     model = icepack.models.IceStream()
     opts = {'dirichlet_ids': [1], 'side_wall_ids': [3, 4]}
@@ -170,8 +173,10 @@ def test_diagnostic_solver_convergence():
                 fluidity=A,
                 friction=C
             )
-            error.append(norm(u_exact - u, 'H1') / norm(u_exact, 'H1'))
+            error.append(norm(u_exact - u) / norm(u_exact))
             delta_x.append(Lx / N)
+
+            print(delta_x[-1], error[-1])
 
         log_delta_x = np.log2(np.array(delta_x))
         log_error = np.log2(np.array(error))
@@ -195,79 +200,3 @@ def test_computing_surface():
     s = icepack.compute_surface(h=h, b=b)
     x0, y0 = Lx/2, Ly/2
     assert abs(s((x0, y0)) - (1 - ρ_I / ρ_W) * h((x0, y0))) < 1e-8
-
-
-# Test solving the coupled diagnostic/prognostic equations for an ice stream
-# and check that it doesn't explode. TODO: Manufacture a solution.
-def test_ice_stream_prognostic_solve():
-    Lx, Ly = 20e3, 20e3
-    h0, dh = 500.0, 100.0
-    T = 254.15
-    u0 = 100.0
-
-    model = icepack.models.IceStream()
-    opts = {'dirichlet_ids': [1], 'side_wall_ids': [3, 4]}
-
-    N = 32
-    mesh = firedrake.RectangleMesh(N, N, Lx, Ly)
-
-    V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=2)
-    Q = firedrake.FunctionSpace(mesh, family='CG', degree=2)
-    solver = icepack.solvers.FlowSolver(model, **opts)
-
-    x, y = firedrake.SpatialCoordinate(mesh)
-    height_above_flotation = 10.0
-    d = -ρ_I / ρ_W * (h0 - dh) + height_above_flotation
-    ρ = ρ_I - ρ_W * d**2 / (h0 - dh)**2
-
-    Z = icepack.rate_factor(T) * (ρ * g * h0 / 4)**n
-    q = 1 - (1 - (dh/h0) * (x/Lx))**(n + 1)
-    ux = u0 + Z * q * Lx * (h0/dh) / (n + 1)
-    u0 = interpolate(firedrake.as_vector((ux, 0)), V)
-
-    thickness = h0 - dh * x / Lx
-    β = 1/2
-    α = β * ρ / ρ_I * dh / Lx
-    h = interpolate(h0 - dh * x / Lx, Q)
-    h_inflow = h.copy(deepcopy=True)
-    ds = (1 + β) * ρ / ρ_I * dh
-    s = interpolate(d + h0 - dh + ds * (1 - x / Lx), Q)
-    b = interpolate(s - h, Q)
-
-    C = interpolate(α * (ρ_I * g * thickness) * ux**(-1/m), Q)
-    A = firedrake.Constant(icepack.rate_factor(T))
-
-    final_time = 1.0
-    timestep = 2 / N
-    num_timesteps = int(final_time / timestep)
-    dt = final_time / num_timesteps
-
-    u = solver.diagnostic_solve(
-        velocity=u0, thickness=h, surface=s, friction=C, fluidity=A
-    )
-
-    a = firedrake.Function(Q)
-    h_n = solver.prognostic_solve(
-        dt, thickness=h, velocity=u, accumulation=a, thickness_inflow=h_inflow
-    )
-    a.interpolate((h_n - h) / dt)
-
-    for step in range(num_timesteps):
-        h = solver.prognostic_solve(
-            dt,
-            thickness=h,
-            velocity=u,
-            accumulation=a,
-            thickness_inflow=h_inflow
-        )
-        s = icepack.compute_surface(thickness=h, bed=b)
-
-        u = solver.diagnostic_solve(
-            velocity=u,
-            thickness=h,
-            surface=s,
-            friction=C,
-            fluidity=A
-        )
-
-    assert norm(h, 'Linfty') < np.inf

--- a/test/mass_transport_test.py
+++ b/test/mass_transport_test.py
@@ -1,0 +1,300 @@
+# Copyright (C) 2017-2020 by Daniel Shapero <shapero@uw.edu>
+#
+# This file is part of icepack.
+#
+# icepack is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# The full text of the license can be found in the file LICENSE in the
+# icepack source directory or at <http://www.gnu.org/licenses/>.
+
+import pytest
+import numpy as np
+import firedrake
+from firedrake import interpolate
+import icepack
+
+def norm(v):
+    return icepack.norm(v, norm_type='L1')
+
+
+# Test solving the mass transport equations with a constant velocity field
+# and check that the solutions converge to the exact solution obtained from
+# the method of characteristics.
+def test_mass_transport_solver_convergence():
+    Lx, Ly = 1.0, 1.0
+    u0 = 1.0
+    h_in, dh = 1.0, 0.2
+
+    delta_x, error = [], []
+    model = icepack.models.IceShelf()
+    for N in range(24, 97, 4):
+        delta_x.append(Lx / N)
+
+        mesh = firedrake.RectangleMesh(N, N, Lx, Ly)
+        x, y = firedrake.SpatialCoordinate(mesh)
+
+        degree = 1
+        V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=degree)
+        Q = firedrake.FunctionSpace(mesh, family='CG', degree=degree)
+        solver = icepack.solvers.FlowSolver(model)
+
+        h0 = interpolate(h_in - dh * x / Lx, Q)
+        a = firedrake.Function(Q)
+        u = interpolate(firedrake.as_vector((u0, 0)), V)
+        T = 0.5
+        δx = 1.0 / N
+        δt = δx / u0
+        num_timesteps = int(T / δt)
+
+        h = h0.copy(deepcopy=True)
+        for step in range(num_timesteps):
+            h = solver.prognostic_solve(
+                δt,
+                thickness=h,
+                velocity=u,
+                accumulation=a,
+                thickness_inflow=h0
+            )
+
+        z = x - u0 * num_timesteps * δt
+        h_exact = interpolate(h_in - dh/Lx * firedrake.max_value(0, z), Q)
+        error.append(norm(h - h_exact) / norm(h_exact))
+        print(delta_x[-1], error[-1])
+
+    log_delta_x = np.log2(np.array(delta_x))
+    log_error = np.log2(np.array(error))
+    slope, intercept = np.polyfit(log_delta_x, log_error, 1)
+
+    print('log(error) ~= {:g} * log(dx) + {:g}'.format(slope, intercept))
+    assert slope > degree - 0.1
+
+
+from icepack.constants import (
+    ice_density as ρ_I,
+    water_density as ρ_W,
+    glen_flow_law as n,
+    weertman_sliding_law as m,
+    gravity as g
+)
+
+
+# Test solving the coupled diagnostic/prognostic equations for an ice shelf
+# with thickness and velocity fields that are exactly insteady state.
+def test_ice_shelf_prognostic_solver():
+    ρ = ρ_I * (1 - ρ_I / ρ_W)
+
+    Lx, Ly = 20.0e3, 20.0e3
+    h0 = 500.0
+    u0 = 100.0
+    T = 254.15
+
+    model = icepack.models.IceShelf()
+    opts = {'dirichlet_ids': [1], 'side_wall_ids': [3, 4]}
+
+    delta_x, error = [], []
+    for N in range(16, 65, 4):
+        delta_x.append(Lx / N)
+
+        mesh = firedrake.RectangleMesh(N, N, Lx, Ly)
+        x, y = firedrake.SpatialCoordinate(mesh)
+
+        degree = 2
+        V = firedrake.VectorFunctionSpace(mesh, 'CG', degree)
+        Q = firedrake.FunctionSpace(mesh, 'CG', degree)
+
+        q = (n + 1) * (ρ * g * h0 * u0 / 4)**n * icepack.rate_factor(T)
+        ux = (u0**(n + 1) + q * x)**(1/(n + 1))
+
+        h = interpolate(h0 * u0 / ux, Q)
+        h_initial = h.copy(deepcopy=True)
+
+        A = firedrake.Constant(icepack.rate_factor(T))
+        a = firedrake.Constant(0)
+
+        solver = icepack.solvers.FlowSolver(model, **opts)
+        u_guess = interpolate(firedrake.as_vector((ux, 0)), V)
+        u = solver.diagnostic_solve(
+            velocity=u_guess, thickness=h, fluidity=A
+        )
+
+        final_time, dt = 1.0, 1.0/12
+        num_timesteps = int(final_time / dt)
+
+        for k in range(num_timesteps):
+            h = solver.prognostic_solve(
+                dt,
+                thickness=h,
+                velocity=u,
+                accumulation=a,
+                thickness_inflow=h_initial
+            )
+
+            u = solver.diagnostic_solve(
+                velocity=u,
+                thickness=h,
+                fluidity=A
+            )
+
+        error.append(norm(h - h_initial) / norm(h_initial))
+        print(delta_x[-1], error[-1])
+
+    log_delta_x = np.log2(np.array(delta_x))
+    log_error = np.log2(np.array(error))
+    slope, intercept = np.polyfit(log_delta_x, log_error, 1)
+
+    print('log(error) ~= {:g} * log(dx) + {:g}'.format(slope, intercept))
+    assert slope > degree - 0.05
+
+
+# Test solving the coupled diagnostic/prognostic equations for an ice stream
+# and check that it doesn't explode. TODO: Manufacture a solution.
+def test_ice_stream_prognostic_solve():
+    Lx, Ly = 20e3, 20e3
+    h0, dh = 500.0, 100.0
+    T = 254.15
+    u0 = 100.0
+
+    model = icepack.models.IceStream()
+    opts = {'dirichlet_ids': [1], 'side_wall_ids': [3, 4]}
+
+    N = 32
+    mesh = firedrake.RectangleMesh(N, N, Lx, Ly)
+
+    V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=2)
+    Q = firedrake.FunctionSpace(mesh, family='CG', degree=2)
+    solver = icepack.solvers.FlowSolver(model, **opts)
+
+    x, y = firedrake.SpatialCoordinate(mesh)
+    height_above_flotation = 10.0
+    d = -ρ_I / ρ_W * (h0 - dh) + height_above_flotation
+    ρ = ρ_I - ρ_W * d**2 / (h0 - dh)**2
+
+    Z = icepack.rate_factor(T) * (ρ * g * h0 / 4)**n
+    q = 1 - (1 - (dh/h0) * (x/Lx))**(n + 1)
+    ux = u0 + Z * q * Lx * (h0/dh) / (n + 1)
+    u0 = interpolate(firedrake.as_vector((ux, 0)), V)
+
+    thickness = h0 - dh * x / Lx
+    β = 1/2
+    α = β * ρ / ρ_I * dh / Lx
+    h = interpolate(h0 - dh * x / Lx, Q)
+    h_inflow = h.copy(deepcopy=True)
+    ds = (1 + β) * ρ / ρ_I * dh
+    s = interpolate(d + h0 - dh + ds * (1 - x / Lx), Q)
+    b = interpolate(s - h, Q)
+
+    C = interpolate(α * (ρ_I * g * thickness) * ux**(-1/m), Q)
+    A = firedrake.Constant(icepack.rate_factor(T))
+
+    final_time, dt = 1.0, 1.0/12
+    num_timesteps = int(final_time / dt)
+
+    u = solver.diagnostic_solve(
+        velocity=u0, thickness=h, surface=s, friction=C, fluidity=A
+    )
+
+    a = firedrake.Function(Q)
+    h_n = solver.prognostic_solve(
+        dt, thickness=h, velocity=u, accumulation=a, thickness_inflow=h_inflow
+    )
+    a.interpolate((h_n - h) / dt)
+
+    for k in range(num_timesteps):
+        h = solver.prognostic_solve(
+            dt,
+            thickness=h,
+            velocity=u,
+            accumulation=a,
+            thickness_inflow=h_inflow
+        )
+        s = icepack.compute_surface(thickness=h, bed=b)
+
+        u = solver.diagnostic_solve(
+            velocity=u,
+            thickness=h,
+            surface=s,
+            friction=C,
+            fluidity=A
+        )
+
+    assert icepack.norm(h, norm_type='Linfty') < np.inf
+
+
+# Test solving the coupled diagnostic/prognostic equations for the hybrid flow
+# model and check that it doesn't explode.
+def test_hybrid_prognostic_solve():
+    Lx, Ly = 20e3, 20e3
+    h0, dh = 500.0, 100.0
+    T = 254.15
+    u_in = 100.0
+
+    model = icepack.models.HybridModel()
+    opts = {'dirichlet_ids': [1], 'side_wall_ids': [3, 4], 'tolerance': 1e-12}
+
+    Nx, Ny = 32, 32
+    mesh2d = firedrake.RectangleMesh(Nx, Ny, Lx, Ly)
+    mesh = firedrake.ExtrudedMesh(mesh2d, layers=1)
+
+    V = firedrake.VectorFunctionSpace(mesh, dim=2, family='CG', degree=2,
+                                      vfamily='GL', vdegree=1)
+    Q = firedrake.FunctionSpace(mesh, family='CG', degree=2,
+                                vfamily='DG', vdegree=0)
+
+    x, y, ζ = firedrake.SpatialCoordinate(mesh)
+    height_above_flotation = 10.0
+    d = -ρ_I / ρ_W * (h0 - dh) + height_above_flotation
+    ρ = ρ_I - ρ_W * d**2 / (h0 - dh)**2
+
+    Z = icepack.rate_factor(T) * (ρ * g * h0 / 4)**n
+    q = 1 - (1 - (dh/h0) * (x/Lx))**(n + 1)
+    ux = u_in + Z * q * Lx * (h0/dh) / (n + 1)
+    u0 = interpolate(firedrake.as_vector((ux, 0)), V)
+
+    thickness = h0 - dh * x / Lx
+    β = 1/2
+    α = β * ρ / ρ_I * dh / Lx
+    h = interpolate(h0 - dh * x / Lx, Q)
+    h_inflow = h.copy(deepcopy=True)
+    ds = (1 + β) * ρ / ρ_I * dh
+    s = interpolate(d + h0 - dh + ds * (1 - x / Lx), Q)
+    b = interpolate(s - h, Q)
+
+    C = interpolate(α * (ρ_I * g * thickness) * ux**(-1/m), Q)
+    A = firedrake.Constant(icepack.rate_factor(T))
+
+    final_time, dt = 1.0, 1.0/12
+    num_timesteps = int(final_time / dt)
+
+    solver = icepack.solvers.FlowSolver(model, **opts)
+    u = solver.diagnostic_solve(
+        velocity=u0, thickness=h, surface=s, fluidity=A, friction=C
+    )
+
+    a = firedrake.Function(Q)
+    h_n = solver.prognostic_solve(
+        dt, thickness=h, velocity=u, accumulation=a, thickness_inflow=h_inflow
+    )
+    a.interpolate((h_n - h) / dt)
+
+    for k in range(num_timesteps):
+        h = solver.prognostic_solve(
+            dt,
+            thickness=h,
+            velocity=u,
+            accumulation=a,
+            thickness_inflow=h_inflow
+        )
+        s = icepack.compute_surface(thickness=h, bed=b)
+
+        u = solver.diagnostic_solve(
+            velocity=u,
+            thickness=h,
+            surface=s,
+            fluidity=A,
+            friction=C
+        )
+
+    assert icepack.norm(h, norm_type='Linfty') < np.inf

--- a/test/shallow_ice_test.py
+++ b/test/shallow_ice_test.py
@@ -106,6 +106,10 @@ def test_diagnostic_solver_convergence():
             error.append(norm(u_exact - u_num) / norm(u_exact))
             delta_x.append(R / N)
 
+            print(delta_x[-1], error[-1])
+
+            assert assemble(model.scale(velocity=u_num)) > 0
+
         log_delta_x = np.log2(np.array(delta_x))
         log_error = np.log2(np.array(error))
         slope, intercept = np.polyfit(log_delta_x, log_error, 1)


### PR DESCRIPTION
Revert commits:
* 6167dd02df7094b70d668a45762fc35cd342c28d
* ac37ab73521e73545982110782405cf04729d39b
* e4d9c3b4d4e4b30b4e2254d56204539f6b076f52
* ce922849a71ebf3f09a3854a08213b719104ac27
* f8ed459946b1f4245c3981dfe1613c037c5d33af

Transitioning to PETSc SNES was too hasty; the hand-written optimization
solver appears to be more robust to the kind of pathological input data
that one encounters at intermediate stages of an inverse solver. It
might be feasible to switch to PETSc SNES at a later date but this will
require either trust region methods or bounds-constrained optimization
to keep the parameters guesses sensible.