### PR TITLE
switch to using pooch dataset registry file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include icepack/registry.txt

--- a/icepack/datasets.py
+++ b/icepack/datasets.py
@@ -72,12 +72,14 @@ nsidc_data.load_registry(registry_file)
 
 
 def fetch_measures_antarctica():
+    r"""Fetch the MEaSUREs Antarctic velocity map"""
     return nsidc_data.fetch(
         'antarctic_ice_vel_phase_map_v01.nc', downloader=_earthdata_downloader
     )
 
 
 def fetch_measures_greenland():
+    r"""Fetch the MEaSUREs Greenland velocity map"""
     return [
         nsidc_data.fetch(
             'greenland_vel_mosaic200_2015_2016_{}_v02.1.tif'.format(field_name),
@@ -88,6 +90,8 @@ def fetch_measures_greenland():
 
 
 def fetch_bedmachine_antarctica():
+    r"""Fetch the BedMachine map of Antarctic ice thickness, surface elevation,
+    and bed elevation"""
     return nsidc_data.fetch(
         'BedMachineAntarctica_2019-11-05_v01.nc',
         downloader=_earthdata_downloader
@@ -107,11 +111,13 @@ larsen_outline = pooch.create(
 
 
 def fetch_larsen_outline():
+    r"""Fetch an outline of the Larsen C Ice Shelf"""
     downloader = pooch.HTTPDownloader(progressbar=True)
     return larsen_outline.fetch('larsen.geojson', downloader=downloader)
 
 
 def fetch_mosaic_of_antarctica():
+    r"""Fetch the MODIS optical image mosaic of Antarctica"""
     return nsidc_data.fetch(
         'moa750_2009_hp1_v01.1.tif.gz',
         downloader=_earthdata_downloader,

--- a/icepack/datasets.py
+++ b/icepack/datasets.py
@@ -13,6 +13,7 @@
 r"""Routines for fetching the glaciological data sets used in the demos"""
 
 import os
+import pkg_resources
 from getpass import getpass
 import requests
 import pooch
@@ -39,40 +40,25 @@ def _earthdata_downloader(url, output_file, dataset):
         raise error
 
 
-nsidc_url = 'https://daacdata.apps.nsidc.org/pub/DATASETS/'
-
-measures_antarctica = pooch.create(
+nsidc_data = pooch.create(
     path=pooch.os_cache('icepack'),
-    base_url='https://n5eil01u.ecs.nsidc.org/MEASURES/NSIDC-0754.001/1996.01.01/',
-    registry={
-        'antarctic_ice_vel_phase_map_v01.nc':
-        'fa0957618b8bd98099f4a419d7dc0e3a2c562d89e9791b4d0ed55e6017f52416'
-    }
+    base_url='',
+    registry=None
 )
+
+registry_file = pkg_resources.resource_stream('icepack', 'registry.txt')
+nsidc_data.load_registry(registry_file)
+
 
 def fetch_measures_antarctica():
-    return measures_antarctica.fetch('antarctic_ice_vel_phase_map_v01.nc',
-                                     downloader=_earthdata_downloader)
+    return nsidc_data.fetch(
+        'antarctic_ice_vel_phase_map_v01.nc', downloader=_earthdata_downloader
+    )
 
-
-measures_greenland = pooch.create(
-    path=pooch.os_cache('icepack'),
-    base_url=nsidc_url + 'NSIDC-0478.002/2015.0.01/',
-    registry={
-        'greenland_vel_mosaic200_2015_2016_vx_v02.1.tif':
-        '77b8eb65a4718da055bb048b75c35b48ca43d76b5bffb650932128d60ed28598',
-        'greenland_vel_mosaic200_2015_2016_vy_v02.1.tif':
-        'fb5dbc07d032de9b1bdb0b990ed02a384964d73a150529515038139efb1e3193',
-        'greenland_vel_mosaic200_2015_2016_ex_v02.1.tif':
-        '7e980fb7845fb8517f3791c9b3912ac62d3ce760938d062f1a4d575fad02ad89',
-        'greenland_vel_mosaic200_2015_2016_ey_v02.1.tif':
-        '9a43092b4c92ac767dbc4e6b7d42e55887420bec94eb654382d724d2a2ab6d9a'
-    }
-)
 
 def fetch_measures_greenland():
     return [
-        measures_greenland.fetch(
+        nsidc_data.fetch(
             'greenland_vel_mosaic200_2015_2016_{}_v02.1.tif'.format(field_name),
             downloader=_earthdata_downloader
         )
@@ -80,35 +66,11 @@ def fetch_measures_greenland():
     ]
 
 
-bedmap2 = pooch.create(
-    path=pooch.os_cache('icepack'),
-    base_url='https://secure.antarctica.ac.uk/data/bedmap2/',
-    registry={
-        'bedmap2_tiff.zip':
-        'f4bb27ce05197e9d29e4249d64a947b93aab264c3b4e6cbf49d6b339fb6c67fe'
-    }
-)
-
-def fetch_bedmap2():
-    downloader = pooch.HTTPDownloader(progressbar=True)
-    filenames = bedmap2.fetch(
-        'bedmap2_tiff.zip', processor=pooch.Unzip(), downloader=downloader
-    )
-    return [f for f in filenames if os.path.splitext(f)[1] == '.tif']
-
-
-bedmachine_antarctica = pooch.create(
-    path=pooch.os_cache('icepack'),
-    base_url='https://n5eil01u.ecs.nsidc.org/MEASURES/NSIDC-0756.001/1970.01.01/',
-    registry={
-        'BedMachineAntarctica_2019-11-05_v01.nc':
-        '06a01511a51bbc27d5080e4727a6523126659fe62402b03654a5335e25b614c0'
-    }
-)
-
 def fetch_bedmachine_antarctica():
-    return bedmachine_antarctica.fetch('BedMachineAntarctica_2019-11-05_v01.nc',
-                                       downloader=_earthdata_downloader)
+    return nsidc_data.fetch(
+        'BedMachineAntarctica_2019-11-05_v01.nc',
+        downloader=_earthdata_downloader
+    )
 
 
 outlines_url = 'https://raw.githubusercontent.com/icepack/glacier-meshes/'
@@ -122,23 +84,14 @@ larsen_outline = pooch.create(
     }
 )
 
+
 def fetch_larsen_outline():
-    return larsen_outline.fetch(
-        'larsen.geojson', downloader=pooch.HTTPDownloader(progressbar=True)
-    )
+    downloader = pooch.HTTPDownloader(progressbar=True)
+    return larsen_outline.fetch('larsen.geojson', downloader=downloader)
 
-
-moa = pooch.create(
-    path=pooch.os_cache('icepack'),
-    base_url=nsidc_url + 'nsidc0593_moa2009/geotiff/',
-    registry={
-        'moa750_2009_hp1_v01.1.tif.gz':
-        '90d1718ea0971795ec102482c47f308ba08ba2b88383facb9fe210877e80282c'
-    }
-)
 
 def fetch_mosaic_of_antarctica():
-    return moa.fetch(
+    return nsidc_data.fetch(
         'moa750_2009_hp1_v01.1.tif.gz',
         downloader=_earthdata_downloader,
         processor=pooch.Decompress()

--- a/icepack/registry.txt
+++ b/icepack/registry.txt
@@ -1,0 +1,9 @@
+antarctic_ice_vel_phase_map_v01.nc fa0957618b8bd98099f4a419d7dc0e3a2c562d89e9791b4d0ed55e6017f52416 https://n5eil01u.ecs.nsidc.org/MEASURES/NSIDC-0754.001/1996.01.01/antarctic_ice_vel_phase_map_v01.nc
+BedMachineAntarctica_2019-11-05_v01.nc 06a01511a51bbc27d5080e4727a6523126659fe62402b03654a5335e25b614c0 https://n5eil01u.ecs.nsidc.org/MEASURES/NSIDC-0756.001/1970.01.01/BedMachineAntarctica_2019-11-05_v01.nc
+moa750_2009_hp1_v01.1.tif.gz 90d1718ea0971795ec102482c47f308ba08ba2b88383facb9fe210877e80282c https://daacdata.apps.nsidc.org/pub/DATASETS/nsidc0593_moa2009/geotiff/moa750_2009_hp1_v01.1.tif.gz
+
+greenland_vel_mosaic200_2015_2016_vx_v02.1.tif 77b8eb65a4718da055bb048b75c35b48ca43d76b5bffb650932128d60ed28598 https://n5eil01u.ecs.nsidc.org/MEASURES/NSIDC-0478.002/2015.09.01/greenland_vel_mosaic200_2015_2016_vx_v02.1.tif
+greenland_vel_mosaic200_2015_2016_vy_v02.1.tif fb5dbc07d032de9b1bdb0b990ed02a384964d73a150529515038139efb1e3193 https://n5eil01u.ecs.nsidc.org/MEASURES/NSIDC-0478.002/2015.09.01/greenland_vel_mosaic200_2015_2016_vy_v02.1.tif
+greenland_vel_mosaic200_2015_2016_ex_v02.1.tif 7e980fb7845fb8517f3791c9b3912ac62d3ce760938d062f1a4d575fad02ad89 https://n5eil01u.ecs.nsidc.org/MEASURES/NSIDC-0478.002/2015.09.01/greenland_vel_mosaic200_2015_2016_ex_v02.1.tif
+greenland_vel_mosaic200_2015_2016_ey_v02.1.tif 9a43092b4c92ac767dbc4e6b7d42e55887420bec94eb654382d724d2a2ab6d9a https://n5eil01u.ecs.nsidc.org/MEASURES/NSIDC-0478.002/2015.09.01/greenland_vel_mosaic200_2015_2016_ey_v02.1.tif
+

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,6 @@
 # The full text of the license can be found in the file LICENSE in the
 # icepack source directory or at <http://www.gnu.org/licenses/>.
 
-from glob import glob
-from os.path import basename, splitext
 from setuptools import setup, find_packages
 
 setup(
@@ -22,6 +20,7 @@ setup(
     author='Daniel Shapero',
     url='https://github.com/icepack/icepack',
     packages=find_packages(exclude=['doc', 'test']),
+    package_data={'icepack': ['registry.txt']},
     install_requires=['numpy', 'scipy', 'matplotlib', 'rasterio>=1.0.26',
                       'netCDF4', 'geojson', 'shapely', 'pooch>=1.0.0',
                       'pygmsh', 'meshio>=3.3.1', 'tqdm'],


### PR DESCRIPTION
This patch switches us to using a separate registry text file to describe the datasets to download from NSIDC rather than hard-coding the filenames, URLs, and hashes into datasets.py. See [this page](https://www.fatiando.org/pooch/latest/usage.html#so-you-have-1000-data-files) from the pooch documentation for more on registry files.

Making this change will help us move towards automated testing using real observational data, rather than just synthetic problems. The datasets we use (BedMachine, MEaSUREs Antarctica) are often 4GB or more. Downloading them every time or baking them into the Docker image is impractical We can instead take subsets of these maps for, say, Larsen or Pine Island using `rio warp`. These smaller chunks are more like ~16MB each. We can then bake these into the testing docker image when it's built. We'll then replace the registry file with a patched version so that the hashes match. Testing on real data will help us avoid goof-ups like #51 .