### PR TITLE
Factor out diagnostic solver from FlowSolver and add hooks for solver options

### DIFF
--- a/icepack/solvers/flow_solver.py
+++ b/icepack/solvers/flow_solver.py
@@ -23,8 +23,65 @@ from ..utilities import default_solver_parameters
 
 
 class FlowSolver:
-    r"""Solves the diagnostic and prognostic models of ice physics"""
     def __init__(self, model, **kwargs):
+        r"""Solves the diagnostic and prognostic models of ice physics
+
+        This class is responsible for efficiently solving the physics
+        problem you have chosen. (This is contrast to classes like
+        IceStream, which is where you choose what that physics problem
+        is.) If you want to make your simulation run faster, you can select
+        different solvers and options.
+
+        Parameters
+        ----------
+        model
+            The flow model object -- IceShelf, IceStream, etc.
+        dirichlet_ids : list of int, optional
+            Numerical IDs of the boundary segments where the ice velocity
+            should be fixed
+        side_wall_ids : list of int, optional
+            Numerical IDs of the boundary segments where the ice velocity
+            should have no normal flow
+        diagnostic_solver_type : {'icepack', 'petsc'}, optional
+            Use hand-written optimization solver ('icepack') or PETSc SNES
+            ('petsc'), defaults to 'icepack'
+        diagnostic_solver_parameters : dict, optional
+            Options for the diagnostic solver; defaults to a Newton line
+            search method with direct factorization of the Hessian using
+            MUMPS
+        prognostic_solver_type : {'lax-wendroff', 'implicit-euler'}, optional
+            Timestepping scheme to use for prognostic equations, defaults
+            to Lax-Wendroff
+        prognostic_solver_parameters : dict, optional
+            Options for prognostic solve routine; defaults to direct
+            factorization of the flux matrix using MUMPS
+
+        Examples
+        --------
+
+        Create a flow solver with inflow on boundary segments 1 and 2
+        using the default solver configuration.
+
+        >>> model = icepack.models.IceStream()
+        >>> solver = icepack.solvers.FlowSolver(model, dirichlet_ids=[1, 2])
+
+        Use an iterative linear solver to hopefully accelerate the code.
+
+        >>> opts = {
+        ...     'dirichlet_ids': [1, 2],
+        ...     'diagnostic_solver_type': 'petsc',
+        ...     'diagnostic_solver_parameters': {
+        ...         'ksp_type': 'cg',
+        ...         'pc_type': 'ilu',
+        ...         'pc_factor_fill': 2
+        ...     },
+        ...     'prognostic_solver_parameters': {
+        ...         'ksp_type': 'gmres',
+        ...         'pc_type': 'sor'
+        ...     }
+        ... }
+        >>> solver = icepack.solvers.FlowSolver(model, **opts)
+        """
         self._model = model
         self._fields = {}
 

--- a/icepack/solvers/heat_transport.py
+++ b/icepack/solvers/heat_transport.py
@@ -20,9 +20,13 @@ from ..utilities import default_solver_parameters
 
 
 class HeatTransportSolver:
-    def __init__(self, model):
+    def __init__(self, model, **kwargs):
         self._model = model
         self._fields = {}
+
+        self._solver_parameters = kwargs.get(
+            'solver_parameters', default_solver_parameters
+        )
 
     @property
     def model(self):
@@ -60,7 +64,7 @@ class HeatTransportSolver:
         )
 
         self._solver = firedrake.NonlinearVariationalSolver(
-            problem, solver_parameters=default_solver_parameters
+            problem, solver_parameters=self._solver_parameters
         )
 
         self._energy_old = E_0

--- a/test/heat_transport_test.py
+++ b/test/heat_transport_test.py
@@ -10,6 +10,7 @@
 # The full text of the license can be found in the file LICENSE in the
 # icepack source directory or at <http://www.gnu.org/licenses/>.
 
+import pytest
 import numpy as np
 import firedrake
 from firedrake import assemble, inner, as_vector, Constant, dx, ds_t, ds_b
@@ -54,7 +55,8 @@ E_surface = 480
 q_bed = 50e-3 * year * 1e-6
 
 
-def test_diffusion():
+@pytest.mark.parametrize('params', [{'ksp_type': 'cg', 'pc_type': 'ilu'}, None])
+def test_diffusion(params):
     E_true = firedrake.interpolate(E_surface + q_bed / α * h * (1 - ζ), Q)
     E = firedrake.interpolate(Constant(480), Q)
 
@@ -72,7 +74,9 @@ def test_diffusion():
             return firedrake.Constant(0) * ψ * h * dx
 
     model = DiffusionTransportModel()
-    solver = icepack.solvers.HeatTransportSolver(model)
+    solver = icepack.solvers.HeatTransportSolver(
+        model, solver_parameters=params
+    )
 
     dt = 250.0
     final_time = 6000

--- a/test/ice_shelf_test.py
+++ b/test/ice_shelf_test.py
@@ -10,6 +10,7 @@
 # The full text of the license can be found in the file LICENSE in the
 # icepack source directory or at <http://www.gnu.org/licenses/>.
 
+import pytest
 import numpy as np
 import firedrake
 from firedrake import interpolate, as_vector
@@ -52,10 +53,15 @@ def norm(v):
 
 # Check that the diagnostic solver converges with the expected rate as the
 # mesh is refined using an exact solution of the ice shelf model.
-def test_diagnostic_solver_convergence():
+@pytest.mark.parametrize('solver_type', ['icepack', 'petsc'])
+def test_diagnostic_solver_convergence(solver_type):
     # Create an ice shelf model
     model = icepack.models.IceShelf()
-    opts = {'dirichlet_ids': [1], 'side_wall_ids': [3, 4]}
+    opts = {
+        'dirichlet_ids': [1],
+        'side_wall_ids': [3, 4],
+        'diagnostic_solver_type': solver_type
+    }
 
     # Solve the ice shelf model for successively higher mesh resolution
     for degree in range(1, 4):


### PR DESCRIPTION
This patch does what #50 should have. The responsibility for solving the diagnostic equations has been factored out into a separate class which defaults to the existing implementation -- a handwritten Newton line search optimization solver. Alternatively, you can opt to use PETSc SNES. In the future we might support a PETSc TAO solver as well.

In either case you can now pass solver parameters, for example to make simulations run faster by using the conjugate gradient method with an appropriate preconditioner. I get ~25% speed-ups on the MISMIP+ test case with very little effort this way.

Finally, this should offer a workaround for people who have had troubles on MacOS with different versions of the gfortran runtime library getting linked through MUMPS and scipy (attn @jabadge ). You'd initialize a flow solver like so:

    solver = icepack.solvers.FlowSolver(
        model, solver_parameters={'ksp_type': 'preonly', 'pc_type': 'lu'}
    )

This will use PETSc's LU solver, which is slower than MUMPS but it'll at least work for now.