### PR TITLE
Conditionally import pygmsh

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ rasterio>=1.0.26
 geojson
 shapely
 pooch>=1.0.0
-pygmsh
+pygmsh<=6.1.1
 meshio>=3.3.1
 sphinx[doc]
 sphinxcontrib-bibtex[doc]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_data={'icepack': ['registry.txt']},
     install_requires=['numpy', 'scipy', 'matplotlib', 'rasterio>=1.0.26',
                       'netCDF4', 'geojson', 'shapely', 'pooch>=1.0.0',
-                      'pygmsh', 'meshio>=3.3.1', 'tqdm'],
+                      'pygmsh<=6.1.1', 'meshio>=3.3.1', 'tqdm'],
     extras_require = {
         'doc': ['sphinx', 'sphinxcontrib-bibtex', 'sphinx_rtd_theme',
                 'ipykernel', 'nbconvert']


### PR DESCRIPTION
gmsh requires a full graphics stack and loads several dynamic libraries
that might not exist in a containerized environment. This patch only
imports pygmsh inside the `collection_to_geo` function so that icepack
can still be imported if a user never intends to call that function.