### PR TITLE
documentation improvements

### DIFF
--- a/notebooks/tutorials/00-meshes-functions.ipynb
+++ b/notebooks/tutorials/00-meshes-functions.ipynb
@@ -54,9 +54,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import icepack.plot\n",
-    "fig, axes = icepack.plot.subplots()\n",
-    "icepack.plot.triplot(mesh, axes=axes)\n",
+    "import matplotlib.pyplot as plt\n",
+    "fig, axes = plt.subplots()\n",
+    "firedrake.triplot(mesh, axes=axes)\n",
     "axes.legend();"
    ]
   },
@@ -79,7 +79,11 @@
     "Firedrake has built-in functions for evaluating various transcendental functions of the coordinates, for example the sine, cosine, exponential, logarithm, etc.\n",
     "To see all of the available functions, you can check the namespace `ufl.operators`.\n",
     "\n",
-    "Finally, the function `firedrake.interpolate` takes in an expression and a function space, and returns a field from that function space."
+    "Finally, the function `firedrake.interpolate` takes in an expression and a function space, and returns a field from that function space.\n",
+    "In the code below, the variable `expr` is a purely symbolic object.\n",
+    "The variable `q` on the other hand represents what happens when that expression gets interpolated to some function space.\n",
+    "The space we've chosen can represent polynomials up to degree 2 within each triangle, whereas the expression we're interpolating has polynomials up to degree four.\n",
+    "So there can be some loss of precision when we interpolate an expression to a function space."
    ]
   },
   {
@@ -91,9 +95,24 @@
     "Q = firedrake.FunctionSpace(mesh, family='CG', degree=2)\n",
     "\n",
     "x, y = firedrake.SpatialCoordinate(mesh)\n",
-    "a, b = 0.5, 10.0\n",
+    "a = firedrake.Constant(0.5)\n",
+    "b = firedrake.Constant(10.0)\n",
     "expr = (a - x)**2 + b*(y - x**2)**2\n",
     "q = firedrake.interpolate(expr, Q)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we've defined the variables $a$ and $b$ as a `firedrake.Constant`.\n",
+    "We could have left these as just the floating-point numbers `0.5` and `10.0` and the code still would have worked.\n",
+    "In general you'll want to making something a `Constant` if its value could change from one run of the program to another.\n",
+    "For example, we might want to look at how the shape of this function changes as we alter the parameters.\n",
+    "\n",
+    "Next we'll make a contour plot of the the function we just created.\n",
+    "The functions `tricontour`, `tricontourf`, `tripcolor`, and `quiver` are just wrappers around the equivalent functions in matplotlib.\n",
+    "If you haven't used matplotlib before, you can consult their [example code](https://matplotlib.org/gallery/images_contours_and_fields/tripcolor_demo.html#sphx-glr-gallery-images-contours-and-fields-tripcolor-demo-py) to see how these functions work."
    ]
   },
   {
@@ -102,8 +121,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(q, 36, axes=axes)\n",
+    "fig, axes = plt.subplots()\n",
+    "contours = firedrake.tricontourf(q, 36, axes=axes)\n",
     "fig.colorbar(contours);"
    ]
   },
@@ -111,7 +130,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can make vector fields in much the same way as we make scalar fields, the only difference being the type of function space.\n",
+    "We can make vector fields in much the same way as we make scalar fields.\n",
+    "There are two key differences.\n",
+    "First, we have to put the expression we want inside the function `as_vector` in order to specify that we want a field with more than one component.\n",
+    "(There's also an `as_tensor` function if you want a matrix field.)\n",
+    "Second, we have to interpolate into a vector function space.\n",
+    "Here we'll make a vector field representing the negative gradient of the Rosenbrock function that we just defined above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firedrake import as_vector\n",
+    "expr = as_vector((\n",
+    "    2 * (a - x) + 4 * b * x * (y - x**2),\n",
+    "    -2 * b * (y - x**2)\n",
+    "))\n",
+    "\n",
+    "V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=2)\n",
+    "v = firedrake.interpolate(expr, V)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "There are many ways to plot a vector field.\n",
     "Here we show a plot of the streamlines of the vector field, colored according to the magnitude of the vector.\n",
     "This method is expensive, especially if you set the resolution or spacing of the streamlines to be too small, but nonetheless it produces really nice graphics."
@@ -123,19 +169,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=2)\n",
-    "v = firedrake.interpolate(firedrake.grad(expr), V)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, axes = icepack.plot.subplots()\n",
-    "opts = {'precision': 1/128, 'density': 1/16, 'max_num_points': 128}\n",
-    "streamlines = icepack.plot.streamplot(v, axes=axes, **opts)\n",
+    "fig, axes = plt.subplots()\n",
+    "opts = {'resolution': 1 / 32, 'seed': 1}\n",
+    "streamlines = firedrake.streamplot(v, axes=axes, **opts)\n",
     "fig.colorbar(streamlines);"
    ]
   },
@@ -145,8 +181,8 @@
    "source": [
     "### Post-processing\n",
     "\n",
-    "We've already seen about how to visualize a scalar or a vector field; this is just a call to the function `icepack.plot`.\n",
-    "To analyze the results of a simulation, you might also want to evaluate scalar or vector fields at points in the domain:"
+    "We've shown above how to plot what a scalar or vector field looks like, but there's more to analyzing the results of simulations than just making pretty pictures.\n",
+    "For starters, you might also want to evaluate scalar or vector fields at points in the domain:"
    ]
   },
   {
@@ -166,8 +202,9 @@
    "source": [
     "Firedrake also provides a rich set of operations for evaluating integral expressions of scalar and vector fields.\n",
     "Much like how the function `SpatialCoordinate` gives you two symbols `x`, `y` that represent the coordinates of each point of the mesh, firedrake also provides an object `dx` that represents the differential area element.\n",
-    "\n",
-    "To define an integral, we multiply an expression by `dx`, and then call the function `firedrake.assemble` to evaluate it."
+    "To define an integral, we multiply an expression by `dx`.\n",
+    "This gives back a purely symbolic object representing a recipe for computing an integral; we haven't yet evaluated it to get a real number.\n",
+    "The function `firedrake.assemble` actually evaluates this symbolic expression to give us a number."
    ]
   },
   {
@@ -176,26 +213,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from firedrake import inner, grad, dx, assemble\n",
-    "\n",
-    "print(assemble(x*y*dx))\n",
-    "print(assemble(q*dx))\n",
-    "print(assemble(inner(v, v)*dx))"
+    "from firedrake import inner, dx, assemble\n",
+    "print(assemble(x * y * dx))\n",
+    "print(assemble(q * dx))\n",
+    "print(assemble(inner(v, v) * dx))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also evaluate integrals over the boundary of the mesh.\n",
-    "Boundary integrals are specified using the differential surface element `ds` instead of `dx`.\n",
+    "This is similar to `interpolate`; expressions defining fields are purely symbolic until we `interpolate` them to a function space. \n",
+    "Likewise, expressions defining integrals are purely symbolic until we `assemble` them to get a real number.\n",
     "\n",
-    "Sometimes we need to integrate over only part of the boundary.\n",
-    "We can specify which part by passing the right numeric ID to `ds`; these are the same IDs that are color-coded in the mesh plot above.\n",
-    "\n",
-    "Finally, you might also want to evaluate the flux of a vector field across the boundary.\n",
-    "To evaluate a flux, we need to get the unit outward normal vector to the boundary.\n",
-    "You can get a symbol representing the unit outward normal by calling the function `firedrake.FacetNormal`."
+    "We can also evaluate integrals over the boundary of the mesh rather than the interior.\n",
+    "Boundary integrals are specified using the surface measure `ds` instead of `dx`."
    ]
   },
   {
@@ -205,10 +237,50 @@
    "outputs": [],
    "source": [
     "from firedrake import ds\n",
+    "print(assemble(q * ds))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We might also need more fine-grained control over which part of the boundary we're integrating over.\n",
+    "The mesh plot we created earlier shows the numbering of the boundary segments.\n",
+    "We can specify which boundary segment to integrate over by passing the corresponding numeric ID to `ds`; these are the same IDs that are color-coded in the mesh plot above.\n",
+    "You can also pass a tuple of IDs to integrate over multiple segments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(assemble(q * ds(2)))\n",
     "\n",
-    "print(assemble(q*ds))\n",
-    "print(assemble(q*ds(2)))\n",
+    "ids = (1, 2)\n",
+    "print(assemble(q * ds(ids)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, a common operation we'll need in the tutorials that follow is to evaluate the flux of a vector field $v$ across the boundary of the domain.\n",
+    "The mathematical definition of this quantity is the integral\n",
     "\n",
+    "$$F = \\int_{\\partial\\Omega}v\\cdot n\\, ds$$\n",
+    "\n",
+    "where $n$ is the unit outward-pointing normal vector.\n",
+    "So we'll also need a symbolic representation of the outward-pointing normal; this comes from the function `firedrake.FacetNormal`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "n = firedrake.FacetNormal(mesh)\n",
     "print(assemble(inner(v, n) * ds))"
    ]
@@ -217,15 +289,199 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Common useful functions\n",
+    "\n",
+    "In the tutorials that follow, we'll often have to synthesize some field -- an ice thickness or bed elevation for example -- with a shape that mimics a feature of a real physical system.\n",
+    "There are a few especially useful functions for doing this.\n",
+    "First, the hyperbolic tangent function\n",
+    "\n",
+    "$$\\tanh z = \\frac{\\sinh z}{\\cosh z}$$\n",
+    "\n",
+    "goes from -1 in the limit as $z \\to -\\infty$ and to +1 as $z \\to +\\infty$.\n",
+    "Firedrake also defines symbolic expressions involving transcendental functions like the exponential, logarithm, sine, and cosine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firedrake import exp\n",
+    "\n",
+    "def sinh(z):\n",
+    "    return (exp(z) - exp(-z)) / 2\n",
+    "\n",
+    "def cosh(z):\n",
+    "    return (exp(z) + exp(-z)) / 2\n",
+    "\n",
+    "def tanh(z):\n",
+    "    return sinh(z) / cosh(z)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By shifting and rescaling the output tanh function or its argument, we can create ramping functions that go from one value to another over some length scale that we choose.\n",
+    "Here we'll create a ramp function that goes from a value $a$ to a value $b$ over a distance $\\delta = 1/8$ across the diagonal line through the center of the domain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = firedrake.Constant(-2)\n",
+    "b = firedrake.Constant(+3)\n",
+    "x_0 = firedrake.Constant(1/2)\n",
+    "y_0 = firedrake.Constant(1/2)\n",
+    "δ = firedrake.Constant(1/8)\n",
+    "\n",
+    "w = (x - x_0) / δ + (y - y_0) / δ\n",
+    "expr = a + (b - a) * (tanh(w) + 1) / 2\n",
+    "ramp = firedrake.interpolate(expr, Q)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just to help visualize this a little better, we'll make a 3D plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mpl_toolkits import mplot3d\n",
+    "fig = plt.figure()\n",
+    "axes = fig.add_subplot(projection='3d')\n",
+    "firedrake.trisurf(ramp, axes=axes);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can get more creative about what the argument to the tanh function is to create ramps around more interesting shapes.\n",
+    "Below, we'll create a ramping function around a circle of radius 1/4 in the middle of the domain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firedrake import sqrt\n",
+    "r = sqrt((x - x_0)**2 + (y - y_0)**2)\n",
+    "R = firedrake.Constant(1/4)\n",
+    "ϵ = firedrake.Constant(1/16)\n",
+    "expr = tanh((R - r) / ϵ)\n",
+    "ramp = firedrake.interpolate(expr, Q)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure()\n",
+    "axes = fig.add_subplot(projection='3d')\n",
+    "firedrake.trisurf(ramp, axes=axes);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next useful shaping function is hyperbolic secant:\n",
+    "\n",
+    "$$\\text{sech}\\,z = \\frac{1}{\\cosh z}.$$\n",
+    "\n",
+    "This is good for making bumps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sech(z):\n",
+    "    return 1 / cosh(z)\n",
+    "\n",
+    "expr = sech(r / δ)\n",
+    "bump = firedrake.interpolate(expr, Q)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure()\n",
+    "axes = fig.add_subplot(projection='3d')\n",
+    "firedrake.trisurf(bump, axes=axes);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Depending on how sharp a cutoff is necessary, it's also possible to use other bump functions like $e^{-z^2}$, $\\text{sech}^2$, and so forth.\n",
+    "Again, by being a little creative about the argument to the sech function, we can make more interesting fields.\n",
+    "Here we'll create a ridge at the circle of radius 1/4 about the center of the domain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expr = sech((r - R) / δ)\n",
+    "ridge = firedrake.interpolate(expr, Q)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure()\n",
+    "axes = fig.add_subplot(projection='3d')\n",
+    "firedrake.trisurf(ridge, axes=axes);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll use combinations of bump, ramp, and polynomials functions several times in the tutorials that follow in order to synthesize fields like a bed topography with a desired shape.\n",
+    "For example, we'll use the ridge shape above to emulate a mountain range in the next tutorial."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Conclusion\n",
     "\n",
-    "Icepack uses the functions in firedrake to implement solvers for the various physics problems that show up in ice sheet modeling.\n",
-    "The firedrake routines that we've demonstrated here can be used for analyzing simulation results, either through visualization, evaluating fields at points, or evaluating integrals of fields.\n",
+    "Icepack uses the functions in Firedrake to implement solvers for the various physics problems that show up in ice sheet modeling.\n",
+    "The Firedrake routines that we've shown here can be used for analyzing simulation results, either through visualization, evaluating fields at points, or evaluating integrals of fields.\n",
     "They can also be used to define input fields of simulations, if those fields have a simple analytical expression.\n",
-    "In the next demo, we'll show how to use icepack to solve for the velocity and thickness of a floating ice shelf with a synthetic geometry.\n",
-    "In later demos, we'll show how to use real observational data sets, as well as more complicated geometries imported from mesh generators.\n",
+    "In the next tutorial, we'll show how to use icepack to solve for the velocity and thickness of a an ice sheet with a synthetic geometry.\n",
+    "In later tutorials, we'll show how to use real observational data sets, as well as more complicated geometries imported from mesh generators.\n",
     "\n",
-    "To read more about firedrake, you can visit their [documentation](http://www.firedrakeproject.org/documentation.html) or check out some of the [demos](http://www.firedrakeproject.org/notebooks.html)."
+    "To learn more about Firedrake, you can visit their [documentation](http://www.firedrakeproject.org/documentation.html) or check out some of the [demos](http://www.firedrakeproject.org/notebooks.html)."
    ]
   }
  ],

--- a/notebooks/tutorials/00-meshes-functions.ipynb
+++ b/notebooks/tutorials/00-meshes-functions.ipynb
@@ -1,18 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%matplotlib inline\n",
-    "import matplotlib.pyplot as plt\n",
-    "import firedrake\n",
-    "import icepack, icepack.plot"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -46,6 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import firedrake\n",
     "nx, ny = 16, 16\n",
     "mesh = firedrake.UnitSquareMesh(nx, ny)"
    ]
@@ -65,10 +54,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import icepack.plot\n",
     "fig, axes = icepack.plot.subplots()\n",
     "icepack.plot.triplot(mesh, axes=axes)\n",
-    "axes.legend()\n",
-    "plt.show(fig)"
+    "axes.legend();"
    ]
   },
   {
@@ -104,12 +93,18 @@
     "x, y = firedrake.SpatialCoordinate(mesh)\n",
     "a, b = 0.5, 10.0\n",
     "expr = (a - x)**2 + b*(y - x**2)**2\n",
-    "q = firedrake.interpolate(expr, Q)\n",
-    "\n",
+    "q = firedrake.interpolate(expr, Q)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fig, axes = icepack.plot.subplots()\n",
     "contours = icepack.plot.tricontourf(q, 36, axes=axes)\n",
-    "fig.colorbar(contours)\n",
-    "plt.show(fig)"
+    "fig.colorbar(contours);"
    ]
   },
   {
@@ -129,13 +124,19 @@
    "outputs": [],
    "source": [
     "V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=2)\n",
-    "v = firedrake.interpolate(firedrake.grad(expr), V)\n",
-    "\n",
+    "v = firedrake.interpolate(firedrake.grad(expr), V)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fig, axes = icepack.plot.subplots()\n",
     "opts = {'precision': 1/128, 'density': 1/16, 'max_num_points': 128}\n",
     "streamlines = icepack.plot.streamplot(v, axes=axes, **opts)\n",
-    "fig.colorbar(streamlines)\n",
-    "plt.show(fig)"
+    "fig.colorbar(streamlines);"
    ]
   },
   {

--- a/notebooks/tutorials/01-synthetic-ice-sheet.ipynb
+++ b/notebooks/tutorials/01-synthetic-ice-sheet.ipynb
@@ -1,33 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import tqdm\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "import firedrake\n",
-    "from firedrake import (\n",
-    "    max_value,\n",
-    "    min_value,\n",
-    "    Constant,\n",
-    "    interpolate,\n",
-    "    sqrt,\n",
-    "    inner,\n",
-    "    exp\n",
-    ")\n",
-    "import icepack, icepack.plot\n",
-    "from icepack.constants import (\n",
-    "    ice_density as ρ_I,\n",
-    "    glen_flow_law as n,\n",
-    "    gravity as g\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -69,6 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import firedrake\n",
     "mesh = firedrake.UnitDiskMesh(5)\n",
     "R = 250e3\n",
     "mesh.coordinates.dat.data[:] *= R"
@@ -80,10 +54,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import icepack.plot\n",
     "fig, axes = icepack.plot.subplots()\n",
     "icepack.plot.triplot(mesh, axes=axes)\n",
-    "axes.set_title('Mesh')\n",
-    "plt.show(fig)"
+    "axes.set_title('Mesh');"
    ]
   },
   {
@@ -105,6 +79,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from firedrake import sqrt\n",
     "Q = firedrake.FunctionSpace(mesh, family='CG', degree=2)\n",
     "V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=2)\n",
     "\n",
@@ -127,17 +102,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from firedrake import exp, Constant\n",
+    "\n",
     "# Plateau elevation\n",
-    "b_base = firedrake.Constant(400)\n",
+    "b_base = Constant(400)\n",
     "\n",
     "# Max elevation\n",
-    "b_max = firedrake.Constant(1400)\n",
+    "b_max = Constant(1400)\n",
     "\n",
     "# Radius of the plateau interior\n",
     "ro = 125e3\n",
     "\n",
     "# Radius of the ridge\n",
-    "Ro = firedrake.Constant(200e3)\n",
+    "Ro = Constant(200e3)\n",
     "\n",
     "def tanh(z):\n",
     "    return (exp(z) - exp(-z)) / (exp(z) + exp(-z))\n",
@@ -162,11 +139,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "a = firedrake.Constant(50e3)\n",
+    "from firedrake import interpolate\n",
+    "import numpy as np\n",
+    "a = Constant(50e3)\n",
     "ξ = (sqrt(x**2 + y**2) - ro) / a\n",
     "\n",
     "b_expr_plateau = b_base * (1 - θ(3 * ξ))\n",
-    "\n",
     "b = interpolate(b_expr_plateau, Q)\n",
     "\n",
     "fig, axes = icepack.plot.subplots()\n",
@@ -174,8 +152,7 @@
     "contours = icepack.plot.tricontourf(b, levels, axes=axes, cmap='magma')\n",
     "cb = fig.colorbar(contours)\n",
     "cb.set_label('meters above sea level', rotation=270, labelpad=12)\n",
-    "axes.set_title('Bed Plateau')\n",
-    "plt.show(fig)"
+    "axes.set_title('Bed Plateau');"
    ]
   },
   {
@@ -194,17 +171,14 @@
     "ζ = (r - Ro) / Ro\n",
     "\n",
     "b_expr_ridge = (b_max - b_base) * sech(3 * ξ)\n",
-    "\n",
     "b_expr = b_expr_plateau + b_expr_ridge\n",
-    "\n",
     "b = interpolate(b_expr, Q)\n",
     "\n",
     "fig, axes = icepack.plot.subplots()\n",
     "contours = icepack.plot.tricontourf(b, levels, axes=axes, cmap='magma')\n",
     "cb = fig.colorbar(contours)\n",
     "cb.set_label('meters above sea level', rotation=270, labelpad=12)\n",
-    "axes.set_title('Bed Plateau and Ridge')\n",
-    "plt.show(fig)"
+    "axes.set_title('Bed Plateau and Ridge');"
    ]
   },
   {
@@ -220,16 +194,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ρ1 = firedrake.Constant(1/4)\n",
+    "ρ1 = Constant(1/4)\n",
     "μ1 = 1 - ρ1 * θ(3 * (x - ro/4) / a) * sech(2 * y / a)\n",
     "\n",
-    "ρ2 = firedrake.Constant(3/8)\n",
+    "ρ2 = Constant(3/8)\n",
     "μ2 = 1 - ρ2 * θ(3 * (y - ro/4) / a) * sech(2 * x / a)\n",
     "\n",
-    "ρ3 = firedrake.Constant(1/2)\n",
+    "ρ3 = Constant(1/2)\n",
     "μ3 = 1 - ρ3 * θ(3 * (-x + ro/4) / a) * sech(2 * y / a)\n",
     "\n",
-    "ρ4 = firedrake.Constant(5/8)\n",
+    "ρ4 = Constant(5/8)\n",
     "μ4 = 1 - ρ4 * θ(3 * (-y + ro/4) / a) * sech(2 * x / a)\n",
     "\n",
     "μ = μ1 * μ2 * μ3 * μ4\n",
@@ -237,17 +211,14 @@
     "S = 480 / (1 - Ro / R)\n",
     "\n",
     "b_expr_valleys = (b_max - b_base) * sech(3 * ξ) * μ - θ(5 * ζ) * S * ζ\n",
-    "\n",
     "b_expr = b_expr_plateau + b_expr_valleys\n",
-    "\n",
     "b = interpolate(b_expr, Q)\n",
     "\n",
     "fig, axes = icepack.plot.subplots()\n",
     "contours = icepack.plot.tricontourf(b, levels, axes=axes, cmap='magma')\n",
     "cb = fig.colorbar(contours)\n",
     "cb.set_label('meters above sea level', rotation=270, labelpad=12)\n",
-    "axes.set_title('Bed Plateau, \\n Ridge, and Valleys')\n",
-    "plt.show(fig)"
+    "axes.set_title('Bed Plateau, \\n Ridge, and Valleys');"
    ]
   },
   {
@@ -263,6 +234,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from firedrake import max_value\n",
+    "\n",
     "# Surface elevation\n",
     "max_radius = 195e3\n",
     "dome_height = 2.4e3\n",
@@ -283,8 +256,7 @@
     "contours = icepack.plot.tricontourf(s0, 40, axes=axes, cmap='magma')\n",
     "cb = fig.colorbar(contours)\n",
     "cb.set_label('meters above sea level', rotation=270, labelpad=12)\n",
-    "axes.set_title('Initial Ice \\n Surface Elevation')\n",
-    "plt.show(fig)"
+    "axes.set_title('Initial Ice \\n Surface Elevation');"
    ]
   },
   {
@@ -299,8 +271,7 @@
     "contours_h = icepack.plot.tricontour(h0, levels, axes=axes, cmap='Blues')\n",
     "cb = fig.colorbar(contours_h)\n",
     "cb.set_label('meters', rotation=270, labelpad=15)\n",
-    "axes.set_title('Initial Ice Thickness Contours \\n overlain on Bed Surface')\n",
-    "plt.show(fig)"
+    "axes.set_title('Initial Ice Thickness Contours \\n overlain on Bed Surface');"
    ]
   },
   {
@@ -321,6 +292,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import icepack\n",
     "model = icepack.models.ShallowIce()"
    ]
   },
@@ -362,8 +334,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "T = firedrake.Constant(273.15 - 5)\n",
-    "A = interpolate(icepack.rate_factor(T), Q)"
+    "T = Constant(273.15 - 5)\n",
+    "A = icepack.rate_factor(T)"
    ]
   },
   {
@@ -402,8 +374,7 @@
     "contours = icepack.plot.tricontourf(u, 40, axes=axes, cmap='magma')\n",
     "cb = fig.colorbar(contours)\n",
     "cb.set_label('meters/year', rotation=270, labelpad=15)\n",
-    "axes.set_title('Initial Ice Velocity')\n",
-    "plt.show(fig)"
+    "axes.set_title('Initial Ice Velocity');"
    ]
   },
   {
@@ -419,6 +390,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from firedrake import min_value\n",
     "def mass_balance(s, max_a=0.5, da_ds=0.5/1000, ela=300.0):\n",
     "    return min_value((s - ela) * da_ds, max_a)\n",
     "\n",
@@ -447,6 +419,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import tqdm\n",
+    "\n",
     "dt = 10\n",
     "num_timesteps = 50\n",
     "\n",
@@ -516,8 +490,7 @@
     "contours = icepack.plot.tricontourf(u, 40, axes=axes, cmap='magma')\n",
     "cb = fig.colorbar(contours)\n",
     "cb.set_label('meters/year', rotation=270, labelpad=15)\n",
-    "axes.set_title('Current Velocity')\n",
-    "plt.show(fig)"
+    "axes.set_title('Current Velocity');"
    ]
   },
   {
@@ -530,8 +503,7 @@
     "contours = icepack.plot.tricontourf(s, 40, axes=axes, cmap='magma')\n",
     "cb = fig.colorbar(contours)\n",
     "cb.set_label('meters above sea level', rotation=270, labelpad=15)\n",
-    "axes.set_title('Current Ice \\n Surface Elevation')\n",
-    "plt.show(fig)"
+    "axes.set_title('Current Ice \\n Surface Elevation');"
    ]
   },
   {
@@ -558,8 +530,7 @@
     ")\n",
     "cb = fig.colorbar(contours)\n",
     "cb.set_label('meters', rotation=270, labelpad=15)\n",
-    "axes.set_title('Current minus \\n Original Ice Thickness')\n",
-    "plt.show(fig)"
+    "axes.set_title('Current minus \\n Original Ice Thickness');"
    ]
   },
   {
@@ -580,8 +551,7 @@
     "contours = icepack.plot.tricontourf(dh, levels, axes=axes, cmap='RdBu')\n",
     "cb = fig.colorbar(contours)\n",
     "cb.set_label('meters', rotation=270, labelpad=15)\n",
-    "axes.set_title('Current minus \\n Previous Ice Thickness')\n",
-    "plt.show(fig)"
+    "axes.set_title('Current minus \\n Previous Ice Thickness');"
    ]
   },
   {
@@ -597,12 +567,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import matplotlib.pyplot as plt\n",
     "plt.figure()\n",
     "plt.plot(dt * np.arange(num_timesteps), dh_max)\n",
     "plt.xlabel('years')\n",
     "plt.ylabel('maximum change in thickness (meters)')\n",
-    "axes.set_title('Max Change in Ice Thickness at each Time Step')\n",
-    "plt.show(fig)"
+    "axes.set_title('Max Change in Ice Thickness at each Time Step');"
    ]
   },
   {

--- a/notebooks/tutorials/01-synthetic-ice-sheet.ipynb
+++ b/notebooks/tutorials/01-synthetic-ice-sheet.ipynb
@@ -155,10 +155,9 @@
     "b = interpolate(b_expr_plateau, Q)\n",
     "\n",
     "fig, axes = icepack.plot.subplots()\n",
-    "levels = np.linspace(-600, +1200, 41)\n",
-    "contours = icepack.plot.tricontourf(b, levels, axes=axes, cmap='magma')\n",
-    "cb = fig.colorbar(contours)\n",
-    "cb.set_label('meters above sea level', rotation=270, labelpad=12)\n",
+    "kw = {'vmin': -600, 'vmax': +1200}\n",
+    "colors = icepack.plot.tripcolor(b, axes=axes, **kw)\n",
+    "fig.colorbar(colors, label='meters above sea level')\n",
     "axes.set_title('Bed Plateau');"
    ]
   },
@@ -182,9 +181,8 @@
     "b = interpolate(b_expr, Q)\n",
     "\n",
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(b, levels, axes=axes, cmap='magma')\n",
-    "cb = fig.colorbar(contours)\n",
-    "cb.set_label('meters above sea level', rotation=270, labelpad=12)\n",
+    "contours = icepack.plot.tripcolor(b, axes=axes, **kw)\n",
+    "fig.colorbar(contours, label='meters above sea level')\n",
     "axes.set_title('Bed Plateau and Ridge');"
    ]
   },
@@ -222,9 +220,8 @@
     "b = interpolate(b_expr, Q)\n",
     "\n",
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(b, levels, axes=axes, cmap='magma')\n",
-    "cb = fig.colorbar(contours)\n",
-    "cb.set_label('meters above sea level', rotation=270, labelpad=12)\n",
+    "contours = icepack.plot.tripcolor(b, axes=axes, **kw)\n",
+    "fig.colorbar(contours, label='meters above sea level')\n",
     "axes.set_title('Bed Plateau, \\n Ridge, and Valleys');"
    ]
   },
@@ -260,9 +257,8 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(s0, 40, axes=axes, cmap='magma')\n",
-    "cb = fig.colorbar(contours)\n",
-    "cb.set_label('meters above sea level', rotation=270, labelpad=12)\n",
+    "colors = icepack.plot.tripcolor(s0, axes=axes)\n",
+    "fig.colorbar(colors, label='meters above sea level')\n",
     "axes.set_title('Initial Ice \\n Surface Elevation');"
    ]
   },
@@ -273,11 +269,10 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours_b = icepack.plot.tricontourf(b, 40, axes=axes, cmap='magma')\n",
+    "colors_b = icepack.plot.tripcolor(b, axes=axes)\n",
     "levels = np.linspace(100, 2300, 13)\n",
     "contours_h = icepack.plot.tricontour(h0, levels, axes=axes, cmap='Blues')\n",
-    "cb = fig.colorbar(contours_h)\n",
-    "cb.set_label('meters', rotation=270, labelpad=15)\n",
+    "fig.colorbar(colors_b, label='meters')\n",
     "axes.set_title('Initial Ice Thickness Contours \\n overlain on Bed Surface');"
    ]
   },
@@ -378,9 +373,8 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(u, 40, axes=axes, cmap='magma')\n",
-    "cb = fig.colorbar(contours)\n",
-    "cb.set_label('meters/year', rotation=270, labelpad=15)\n",
+    "colors = icepack.plot.tripcolor(u, axes=axes)\n",
+    "fig.colorbar(colors, label='meters / year')\n",
     "axes.set_title('Initial Ice Velocity');"
    ]
   },
@@ -494,10 +488,9 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(u, 40, axes=axes, cmap='magma')\n",
-    "cb = fig.colorbar(contours)\n",
-    "cb.set_label('meters/year', rotation=270, labelpad=15)\n",
-    "axes.set_title('Current Velocity');"
+    "colors = icepack.plot.tripcolor(u, axes=axes)\n",
+    "fig.colorbar(colors, label='meters / year')\n",
+    "axes.set_title('Final Ice Velocity');"
    ]
   },
   {
@@ -507,10 +500,9 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(s, 40, axes=axes, cmap='magma')\n",
-    "cb = fig.colorbar(contours)\n",
-    "cb.set_label('meters above sea level', rotation=270, labelpad=15)\n",
-    "axes.set_title('Current Ice \\n Surface Elevation');"
+    "colors = icepack.plot.tripcolor(s, axes=axes)\n",
+    "fig.colorbar(colors, label='meters above sea level')\n",
+    "axes.set_title('Final Ice \\n Surface Elevation');"
    ]
   },
   {
@@ -531,13 +523,11 @@
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
     "thickness_change = interpolate(h - h0, Q)\n",
-    "levels = np.linspace(-300, +300, 61)\n",
-    "contours = icepack.plot.tricontourf(\n",
-    "    thickness_change, levels, axes=axes, cmap='RdBu'\n",
+    "colors = icepack.plot.tripcolor(\n",
+    "    thickness_change, vmin=-300, vmax=+300, axes=axes, cmap='RdBu'\n",
     ")\n",
-    "cb = fig.colorbar(contours)\n",
-    "cb.set_label('meters', rotation=270, labelpad=15)\n",
-    "axes.set_title('Current minus \\n Original Ice Thickness');"
+    "fig.colorbar(colors, label='meters')\n",
+    "axes.set_title('Final - Initial\\nIce Thickness');"
    ]
   },
   {
@@ -554,11 +544,11 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "levels = np.linspace(-10, +10, 41)\n",
-    "contours = icepack.plot.tricontourf(dh, levels, axes=axes, cmap='RdBu')\n",
-    "cb = fig.colorbar(contours)\n",
-    "cb.set_label('meters', rotation=270, labelpad=15)\n",
-    "axes.set_title('Current minus \\n Previous Ice Thickness');"
+    "colors = icepack.plot.tripcolor(\n",
+    "    dh, vmin=-10, vmax=+10, axes=axes, cmap='RdBu'\n",
+    ")\n",
+    "fig.colorbar(colors, label='meters')\n",
+    "axes.set_title('Final - Previous\\nIce Thickness');"
    ]
   },
   {

--- a/notebooks/tutorials/01-synthetic-ice-sheet.ipynb
+++ b/notebooks/tutorials/01-synthetic-ice-sheet.ipynb
@@ -49,6 +49,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the previous notebook, we used matplotlib to create figure and axis objects.\n",
+    "In this and the following notebooks, we'll instead use a wrapper function in icepack that equalizes the aspect ratio of plots and sets the axis labelling to work better for domains that are usually on the scale of hundreds of kilometers."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -66,11 +74,10 @@
    "source": [
     "### Input data\n",
     "\n",
-    "To view the input data and start modeling we need to interpolate expressions for the bed, ice surface, ice thickness, velocity, etc. to function spaces defined over the mesh. We'll also define some spatial coordinates that will be helpful later on.\n",
-    "\n",
-    "One function space, Q, will be for scalar fields, such as elevation and ice thickness.\n",
-    "Another function space, V, will be for vector fields, such as velocity.\n",
-    "As we make expressions for the input data, we'll interpolate it onto the appropriate function space."
+    "To create the input data for the model we need to define expressions for the ice bed, surface, thickness, velocity, and accumulation rate.\n",
+    "We'll then interpolate these expressions to function spaces.\n",
+    "One function space, $Q$, will be for scalar fields, such as elevation and ice thickness.\n",
+    "The second function space $V$ will be for vector fields, such as velocity."
    ]
   },
   {
@@ -79,20 +86,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from firedrake import sqrt\n",
     "Q = firedrake.FunctionSpace(mesh, family='CG', degree=2)\n",
-    "V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=2)\n",
-    "\n",
-    "x, y = firedrake.SpatialCoordinate(mesh)\n",
-    "r = sqrt(x**2 + y**2)"
+    "V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=2)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we build up an expression for the bed topography. Note that the process to make this bed topography was messy - it involved trial and error over several hours. \n",
-    "\n",
+    "To build up an expression for the bed toporaphy, we'll use the bump and ramp functions that we showed in the 0th tutorial.\n",
+    "The expression for the bed topography is complex and a little messy; when we wrote this tutorial in the first place, it took a few hours and lots of trial and error.\n",
+    "We'll show how the bed topography was built up in several stages in order to help you understand it better.\n",
     "First let's define some variables and functions."
    ]
   },
@@ -102,7 +106,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from firedrake import exp, Constant\n",
+    "from firedrake import sqrt, exp, Constant\n",
+    "\n",
+    "x, y = firedrake.SpatialCoordinate(mesh)\n",
+    "r = sqrt(x**2 + y**2)\n",
     "\n",
     "# Plateau elevation\n",
     "b_base = Constant(400)\n",

--- a/notebooks/tutorials/02-synthetic-ice-shelf.ipynb
+++ b/notebooks/tutorials/02-synthetic-ice-shelf.ipynb
@@ -200,8 +200,7 @@
     "import matplotlib.pyplot as plt\n",
     "fig, axes = icepack.plot.subplots()\n",
     "icepack.plot.triplot(mesh, axes=axes)\n",
-    "axes.legend()\n",
-    "plt.show(fig)"
+    "axes.legend();"
    ]
   },
   {
@@ -335,9 +334,8 @@
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
     "axes.set_title('Thickness')\n",
-    "contours = icepack.plot.tricontourf(h0, 40, axes=axes)\n",
-    "fig.colorbar(contours)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(h0, axes=axes)\n",
+    "fig.colorbar(colors);"
    ]
   },
   {
@@ -351,8 +349,7 @@
     "streamlines = icepack.plot.streamplot(\n",
     "    u0, precision=1e3, density=2e3, axes=axes\n",
     ")\n",
-    "fig.colorbar(streamlines)\n",
-    "plt.show(fig)"
+    "fig.colorbar(streamlines);"
    ]
   },
   {
@@ -471,8 +468,7 @@
     "streamlines = icepack.plot.streamplot(\n",
     "    u, precision=1e3, density=2e3, axes=axes\n",
     ")\n",
-    "fig.colorbar(streamlines, label='meters/year')\n",
-    "plt.show(fig)"
+    "fig.colorbar(streamlines, label='meters/year');"
    ]
   },
   {
@@ -552,9 +548,8 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(h, 40, axes=axes)\n",
-    "fig.colorbar(contours, label='meters')\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(h, axes=axes)\n",
+    "fig.colorbar(colors, label='meters');"
    ]
   },
   {
@@ -574,8 +569,7 @@
     "streamlines = icepack.plot.streamplot(\n",
     "    u, precision=1e3, density=2e3, axes=axes\n",
     ")\n",
-    "fig.colorbar(streamlines, label='meters/year')\n",
-    "plt.show(fig)"
+    "fig.colorbar(streamlines, label='meters/year');"
    ]
   },
   {
@@ -784,11 +778,10 @@
     "\n",
     "fig, axes = icepack.plot.subplots()\n",
     "axes.get_xaxis().set_visible(False)\n",
-    "colors = firedrake.tripcolor(ε_e, vmin=0.0, vmax=8.0, axes=axes)\n",
+    "colors = firedrake.tripcolor(ε_e, vmin=0, vmax=8, axes=axes)\n",
     "fig.colorbar(\n",
     "    colors, orientation='horizontal', label='m yr${}^{-1}$ km${}^{-1}$'\n",
-    ")\n",
-    "plt.show(fig)"
+    ");"
    ]
   },
   {
@@ -824,7 +817,12 @@
     "There are a few new things about this simulation loop compared to what we showed above.\n",
     "First, the diagnostic solve procedure now takes the damage field as a keyword argument in addition to the other fields we've already seen.\n",
     "We then have to calculate the strain rate and membrane stress tensors, since these are the sources of damage.\n",
-    "Finally, there's another update for the damage field."
+    "Finally, there's another update for the damage field.\n",
+    "\n",
+    "We're also explicitly telling the form compiler what quadrature dgree to use when we calculate the membrane stress tensor.\n",
+    "Firedrake defaults to a large number of quadrature points in order to evaluate that integral as exactly as it can.\n",
+    "But it will also throw a warning if an expression is so complicated that it requires too many quadrature points.\n",
+    "Passing the degree explicitly silences the warning and makes the code run faster without much accuracy loss."
    ]
   },
   {
@@ -834,6 +832,12 @@
    "outputs": [],
    "source": [
     "from icepack.models.viscosity import membrane_stress\n",
+    "degree = D.ufl_element().degree() + 2 * ε.ufl_element().degree()\n",
+    "params = {\n",
+    "    'form_compiler_parameters': {\n",
+    "        'quadrature_degree': degree\n",
+    "    }\n",
+    "}\n",
     "\n",
     "for step in tqdm.trange(num_timesteps):\n",
     "    h = flow_solver.prognostic_solve(\n",
@@ -852,7 +856,7 @@
     "    )\n",
     "    \n",
     "    ε = firedrake.project(sym(grad(u)), S)\n",
-    "    M = firedrake.project((1 - D) * membrane_stress(ε, A), S)\n",
+    "    M = firedrake.project((1 - D) * membrane_stress(ε, A), S, **params)\n",
     "\n",
     "    D = damage_solver.solve(\n",
     "        dt,\n",
@@ -887,8 +891,7 @@
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
     "colors = icepack.plot.tripcolor(D, axes=axes)\n",
-    "fig.colorbar(colors)\n",
-    "plt.show(fig)"
+    "fig.colorbar(colors);"
    ]
   },
   {

--- a/notebooks/tutorials/02-synthetic-ice-shelf.ipynb
+++ b/notebooks/tutorials/02-synthetic-ice-shelf.ipynb
@@ -249,7 +249,8 @@
     "Next, we'll come up with some rather arbitrary and un-physical input data.\n",
     "The basic idea is to make the thickness slope down as you go towards the calving terminus and away from the centerline of an inlet.\n",
     "Likewise the ice speed goes up as you go towards the calving terminus.\n",
-    "In order to make this big nasty algebraic expression, we'll create a list of the perturbation thickness and velocity for each inlet, and combine them all together at the end."
+    "We'll create a list of the perturbation thickness and velocity for each inlet and combine them all together at the end.\n",
+    "See again the 0th demo for how to create bumps, ramps, and other building blocks for synthesizing fields with a desired spatial pattern."
    ]
   },
   {

--- a/notebooks/tutorials/03-larsen-ice-shelf.ipynb
+++ b/notebooks/tutorials/03-larsen-ice-shelf.ipynb
@@ -1,21 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import tqdm\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "import rasterio\n",
-    "import geojson\n",
-    "import firedrake\n",
-    "import icepack, icepack.plot"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -65,6 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import icepack\n",
     "outline_filename = icepack.datasets.fetch_larsen_outline()\n",
     "print(outline_filename)"
    ]
@@ -83,6 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import geojson\n",
     "with open(outline_filename, 'r') as outline_file:\n",
     "    outline = geojson.load(outline_file)"
    ]
@@ -121,6 +108,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
     "features = [feature['geometry'] for feature in outline['features']]\n",
     "xmin, ymin, xmax, ymax = np.inf, np.inf, -np.inf, -np.inf\n",
     "δ = 50e3\n",
@@ -147,6 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import icepack.plot\n",
     "fig, axes = icepack.plot.subplots()\n",
     "\n",
     "for feature in outline['features']:\n",
@@ -154,8 +143,7 @@
     "        xs = np.array(line_string)\n",
     "        axes.plot(xs[:, 0], xs[:, 1], linewidth=2)\n",
     "\n",
-    "axes.set_xlabel('meters')\n",
-    "plt.show(fig)"
+    "axes.set_xlabel('meters');"
    ]
   },
   {
@@ -187,6 +175,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import rasterio\n",
     "image_filename = icepack.datasets.fetch_mosaic_of_antarctica()\n",
     "image_file = rasterio.open(image_filename, 'r')"
    ]
@@ -283,8 +272,7 @@
     "        xs = np.array(line_string)\n",
     "        axes.plot(xs[:, 0], xs[:, 1], linewidth=2)\n",
     "\n",
-    "axes.set_xlabel('meters')\n",
-    "plt.show(fig)"
+    "axes.set_xlabel('meters');"
    ]
   },
   {
@@ -354,6 +342,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import firedrake\n",
     "mesh = firedrake.Mesh('larsen.msh')"
    ]
   },
@@ -380,8 +369,7 @@
     "    'boundary_kw': {'linewidth': 2}\n",
     "}\n",
     "icepack.plot.triplot(mesh, axes=axes, **kwargs)\n",
-    "axes.legend()\n",
-    "plt.show(fig)"
+    "axes.legend();"
    ]
   },
   {
@@ -438,7 +426,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "thickness = rasterio.open('netcdf:' + thickness_filename + ':thickness', 'r')"
+    "thickness = rasterio.open(f'netcdf:{thickness_filename}:thickness', 'r')"
    ]
   },
   {
@@ -472,8 +460,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vx = rasterio.open('netcdf:' + velocity_filename + ':VX', 'r')\n",
-    "vy = rasterio.open('netcdf:' + velocity_filename + ':VY', 'r')"
+    "vx = rasterio.open(f'netcdf:{velocity_filename}:VX', 'r')\n",
+    "vy = rasterio.open(f'netcdf:{velocity_filename}:VY', 'r')"
    ]
   },
   {
@@ -514,8 +502,7 @@
     "streamlines = icepack.plot.streamplot(\n",
     "    u0, precision=1000, density=2500, axes=axes\n",
     ")\n",
-    "fig.colorbar(streamlines, label='meters/year')\n",
-    "plt.show(fig)"
+    "fig.colorbar(streamlines, label='meters/year');"
    ]
   },
   {
@@ -596,12 +583,8 @@
    "outputs": [],
    "source": [
     "fig, axes = subplots()\n",
-    "levels = np.linspace(0., 100., 51)\n",
-    "contours = icepack.plot.tricontourf(\n",
-    "    τ_d, levels, extend='max', axes=axes\n",
-    ")\n",
-    "fig.colorbar(contours, label='kPa')\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(τ_d, vmin=0, vmax=100, axes=axes)\n",
+    "fig.colorbar(colors, label='kPa');"
    ]
   },
   {
@@ -669,12 +652,8 @@
     "    -1e3 * ρ_I * g * (1 - ρ_I / ρ_W) * grad(h**2), V\n",
     ")\n",
     "fig, axes = subplots()\n",
-    "levels = np.linspace(0., 20., 41)\n",
-    "contours = icepack.plot.tricontourf(\n",
-    "    τ_d, levels, extend='max', axes=axes\n",
-    ")\n",
-    "fig.colorbar(contours, label='kPa')\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(τ_d, vmin=0, vmax=20, axes=axes)\n",
+    "fig.colorbar(colors, label='kPa');"
    ]
   },
   {
@@ -716,8 +695,7 @@
     "streamlines = icepack.plot.streamplot(\n",
     "    u, precision=1000, density=2500, axes=axes\n",
     ")\n",
-    "fig.colorbar(streamlines, label='meters/year')\n",
-    "plt.show(fig)"
+    "fig.colorbar(streamlines, label='meters/year');"
    ]
   },
   {
@@ -752,6 +730,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import tqdm\n",
     "a = firedrake.Function(Q)\n",
     "h_init = h.copy(deepcopy=True)\n",
     "\n",
@@ -789,9 +768,8 @@
    "outputs": [],
    "source": [
     "fig, axes = subplots()\n",
-    "contours = icepack.plot.tricontourf(h, 20, alpha=0.6, axes=axes)\n",
-    "fig.colorbar(contours, label='meters')\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(h, axes=axes)\n",
+    "fig.colorbar(colors, label='meters');"
    ]
   },
   {
@@ -812,12 +790,10 @@
     "δh.assign(h - h_init)\n",
     "\n",
     "fig, axes = subplots()\n",
-    "levels = np.linspace(-10, +10, 11)\n",
-    "contours = icepack.plot.tricontourf(\n",
-    "    δh, levels, axes=axes, cmap='RdBu', alpha=0.25, extend='both'\n",
+    "contours = firedrake.tripcolor(\n",
+    "    δh, vmin=-20, vmax=+20, axes=axes, cmap='RdBu'\n",
     ")\n",
-    "fig.colorbar(contours, label='meters')\n",
-    "plt.show(fig)"
+    "fig.colorbar(contours, label='meters');"
    ]
   },
   {

--- a/notebooks/tutorials/04-synthetic-ice-stream.ipynb
+++ b/notebooks/tutorials/04-synthetic-ice-stream.ipynb
@@ -1,19 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import tqdm\n",
-    "import matplotlib.pyplot as plt\n",
-    "import firedrake\n",
-    "from firedrake import inner, div, dx, ds, sqrt\n",
-    "import icepack, icepack.plot"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -56,6 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import firedrake\n",
     "Lx, Ly = 50e3, 12e3\n",
     "nx, ny = 48, 32\n",
     "mesh = firedrake.RectangleMesh(nx, ny, Lx, Ly)\n",
@@ -143,6 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import icepack\n",
     "T = firedrake.Constant(255.0)\n",
     "A = icepack.rate_factor(T)"
    ]
@@ -199,7 +188,7 @@
     "    h = kwargs['thickness']\n",
     "    s = kwargs['surface']\n",
     "    C = kwargs['friction']\n",
-    "    \n",
+    "\n",
     "    p_W = ρ_W * g * firedrake.max_value(0, h - s)\n",
     "    p_I = ρ_I * g * h\n",
     "    ϕ = 1 - p_W / p_I\n",
@@ -248,10 +237,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import icepack.plot\n",
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(u0, 25, axes=axes)\n",
-    "fig.colorbar(contours, ax=axes, fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(u0, axes=axes)\n",
+    "fig.colorbar(colors, ax=axes, fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -268,13 +257,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from firedrake import sqrt, inner\n",
     "τ_b = firedrake.interpolate(\n",
     "    -1e3 * C * ϕ * sqrt(inner(u0, u0))**(1/m - 1)*u0, V\n",
     ")\n",
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(τ_b, 25, axes=axes)\n",
-    "fig.colorbar(contours, label='kPa', fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(τ_b, axes=axes)\n",
+    "fig.colorbar(colors, label='kPa', fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -291,11 +280,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from firedrake import div\n",
     "f = firedrake.interpolate(-div(h0 * u0), Q)\n",
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(f, 25, cmap='RdBu', axes=axes)\n",
-    "fig.colorbar(contours, label='meters/year', fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(f, cmap='RdBu', axes=axes)\n",
+    "fig.colorbar(colors, label='meters/year', fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -316,6 +305,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import tqdm\n",
+    "\n",
     "num_years = 250\n",
     "timesteps_per_year = 2\n",
     "\n",
@@ -367,9 +358,8 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours =  icepack.plot.tricontourf(h, 25, axes=axes)\n",
-    "fig.colorbar(contours, label='meters', fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(h, axes=axes)\n",
+    "fig.colorbar(colors, label='meters', fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -379,9 +369,8 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(u, 25, axes=axes)\n",
-    "fig.colorbar(contours, label='meters/year', fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(u, axes=axes)\n",
+    "fig.colorbar(colors, label='meters/year', fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -399,9 +388,8 @@
    "source": [
     "f = firedrake.interpolate(a - div(h * u), Q)\n",
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(f, 25, cmap='RdBu', axes=axes)\n",
-    "fig.colorbar(contours, label='meters/year', fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(f, cmap='RdBu', axes=axes)\n",
+    "fig.colorbar(colors, label='meters/year', fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -418,6 +406,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
     "xs = np.array([(Lx * k / nx, 0) for k in range(nx + 1)])\n",
     "\n",
     "ss = np.array(s.at(xs, tolerance=1e-10))\n",
@@ -429,8 +418,7 @@
     "axes.plot(xs[:, 0] / 1e3, ss - hs, color='blue')\n",
     "axes.plot(xs[:, 0] / 1e3, ss, color='blue')\n",
     "axes.set_xlabel('distance along centerline (km)')\n",
-    "axes.set_ylabel('elevation (m)')\n",
-    "plt.show(fig)"
+    "axes.set_ylabel('elevation (m)');"
    ]
   },
   {
@@ -449,8 +437,7 @@
     "fig, axes = plt.subplots()\n",
     "axes.plot(xs[:, 0] / 1e3, hs)\n",
     "axes.set_xlabel('distance along centerline (km)')\n",
-    "axes.set_ylabel('thickess (m)')\n",
-    "plt.show(fig)"
+    "axes.set_ylabel('thickess (m)');"
    ]
   },
   {
@@ -538,9 +525,8 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(τ_0, 25, axes=axes)\n",
-    "fig.colorbar(contours, label='MPa', fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(τ_0, axes=axes)\n",
+    "fig.colorbar(colors, label='MPa', fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -609,10 +595,8 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "levels = np.linspace(0., 0.15, 31)\n",
-    "contours = firedrake.tricontourf(τ, levels, extend='both', axes=axes)\n",
-    "fig.colorbar(contours, label='MPa', fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = firedrake.tripcolor(τ, vmin=0, vmax=0.15, axes=axes)\n",
+    "fig.colorbar(colors, label='MPa', fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -664,9 +648,8 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(u_schoof, 25, axes=axes)\n",
-    "fig.colorbar(contours, label='meters/year', fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(u_schoof, axes=axes)\n",
+    "fig.colorbar(colors, label='meters/year', fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -780,8 +763,7 @@
     "fig, axes = plt.subplots()\n",
     "axes.plot(xs[:, 0] / 1e3, hs_weertman - hs_schoof, color='black')\n",
     "axes.set_xlabel('distance along centerline (km)')\n",
-    "axes.set_ylabel('thickness difference (m)')\n",
-    "plt.show(fig)"
+    "axes.set_ylabel('thickness difference (m)');"
    ]
   },
   {

--- a/notebooks/tutorials/05-ice-shelf-inverse.ipynb
+++ b/notebooks/tutorials/05-ice-shelf-inverse.ipynb
@@ -1,20 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "import rasterio\n",
-    "import geojson\n",
-    "import firedrake\n",
-    "import icepack, icepack.plot"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -77,6 +63,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import geojson\n",
+    "import icepack\n",
+    "\n",
     "outline_filename = icepack.datasets.fetch_larsen_outline()\n",
     "with open(outline_filename, 'r') as outline_file:\n",
     "    outline = geojson.load(outline_file)\n",
@@ -101,6 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import firedrake\n",
     "mesh = firedrake.Mesh('larsen.msh')"
    ]
   },
@@ -110,6 +100,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
+    "import rasterio\n",
+    "import icepack.plot\n",
+    "\n",
     "features = [feature['geometry'] for feature in outline['features']]\n",
     "xmin, ymin, xmax, ymax = np.inf, np.inf, -np.inf, -np.inf\n",
     "δ = 50e3\n",
@@ -131,12 +125,19 @@
     "    image = image_file.read(indexes=1, window=window, masked=True)\n",
     "\n",
     "def subplots(*args, **kwargs):\n",
-    "    fig, axes = icepack.plot.subplots()\n",
+    "    fig, axes = icepack.plot.subplots(*args, **kwargs)\n",
     "    xmin, ymin, xmax, ymax = rasterio.windows.bounds(window, transform)\n",
-    "    axes.imshow(\n",
-    "        image, extent=(xmin, xmax, ymin, ymax),\n",
-    "        cmap='Greys_r', vmin=12e3, vmax=16.38e3\n",
-    "    )\n",
+    "    kw = {\n",
+    "        'extent': (xmin, xmax, ymin, ymax),\n",
+    "        'cmap': 'Greys_r',\n",
+    "        'vmin': 12e3,\n",
+    "        'vmax':16.38e3\n",
+    "    }\n",
+    "    try:\n",
+    "        axes.imshow(image, **kw)\n",
+    "    except AttributeError:\n",
+    "        for ax in axes:\n",
+    "            ax.imshow(image, **kw)\n",
     "    \n",
     "    return fig, axes"
    ]
@@ -154,8 +155,7 @@
     "    'boundary_kw': {'linewidth': 2}\n",
     "}\n",
     "icepack.plot.triplot(mesh, axes=axes, **kwargs)\n",
-    "axes.legend()\n",
-    "plt.show(fig)"
+    "axes.legend();"
    ]
   },
   {
@@ -171,13 +171,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from firedrake import inner, grad, dx\n",
+    "\n",
     "thickness_filename = icepack.datasets.fetch_bedmachine_antarctica()\n",
     "thickness = rasterio.open(f'netcdf:{thickness_filename}:thickness', 'r')\n",
     "\n",
     "Q = firedrake.FunctionSpace(mesh, family='CG', degree=2)\n",
     "h0 = icepack.interpolate(thickness, Q)\n",
     "\n",
-    "from firedrake import inner, grad, dx\n",
     "h = h0.copy(deepcopy=True)\n",
     "α = firedrake.Constant(2e3)\n",
     "J = 0.5 * ((h - h0)**2 + α**2 * inner(grad(h), grad(h))) * dx\n",
@@ -227,9 +228,8 @@
    "source": [
     "σ = firedrake.interpolate(firedrake.sqrt(σx**2 + σy**2), Q)\n",
     "fig, axes = subplots()\n",
-    "contours = icepack.plot.tricontourf(σ, 20, alpha=0.9, axes=axes)\n",
-    "fig.colorbar(contours)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(σ, vmin=0, axes=axes)\n",
+    "fig.colorbar(colors);"
    ]
   },
   {
@@ -248,7 +248,7 @@
    "source": [
     "T = firedrake.Constant(260)\n",
     "A0 = icepack.rate_factor(T)\n",
-    "from icepack.constants import glen_flow_law as n\n",
+    "\n",
     "def viscosity(**kwargs):\n",
     "    u = kwargs['velocity']\n",
     "    h = kwargs['thickness']\n",
@@ -273,15 +273,37 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the observed ice velocity and the computed of the ice velocity starting from our assumption that the fluidity is constant in space."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axes = subplots()\n",
-    "contours = icepack.plot.tricontourf(u, 20, alpha=0.6, axes=axes)\n",
-    "fig.colorbar(contours)\n",
-    "plt.show(fig)"
+    "fig, axes = subplots(ncols=2, sharex=True, sharey=True)\n",
+    "for ax in axes:\n",
+    "    ax.get_xaxis().set_visible(False)\n",
+    "kwargs = {'precision': 1000, 'density': 2500, 'vmin': 0, 'vmax': 750}\n",
+    "axes[0].set_title('Computed')\n",
+    "axes[1].set_title('Observed')\n",
+    "icepack.plot.streamplot(u, axes=axes[0], **kwargs)\n",
+    "icepack.plot.streamplot(u_obs, axes=axes[1], **kwargs);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are a few obvious missing features in our initial computed solution.\n",
+    "For example, in this data, there's still a rift emanating from the Gipps Ice Rise.\n",
+    "(In 2017, that rift finished propagating all the way across the terminus and broke off [Iceberg A-68](https://en.wikipedia.org/wiki/Iceberg_A-68).)\n",
+    "Our initial computed velocity is smooth, but the observed velocity has a kink going across the rift.\n",
+    "The objective of the exercise that follows is to compute a fluidity field that will reproduce features like the kink in the velocity pattern that emerges as a result of features like rifts."
    ]
   },
   {
@@ -418,7 +440,7 @@
    "outputs": [],
    "source": [
     "inverse_solver = icepack.inverse.GaussNewtonSolver(\n",
-    "    inverse_problem, callback, search_max_iterations=200\n",
+    "    inverse_problem, callback, search_max_iterations=300\n",
     ")"
    ]
   },
@@ -443,12 +465,10 @@
    "source": [
     "fig, axes = subplots()\n",
     "ϕ = inverse_solver.search_direction\n",
-    "levels = np.linspace(-8., +8., 17)\n",
-    "contours = icepack.plot.tricontourf(\n",
-    "    ϕ, levels=levels, cmap='RdBu_r', extend='both', axes=axes\n",
+    "colors = icepack.plot.tripcolor(\n",
+    "    ϕ, vmin=-8, vmax=+8, cmap='RdBu_r', axes=axes\n",
     ")\n",
-    "fig.colorbar(contours)\n",
-    "plt.show(fig)"
+    "fig.colorbar(colors);"
    ]
   },
   {
@@ -516,12 +536,10 @@
    "source": [
     "θ = inverse_solver.parameter\n",
     "fig, axes = subplots()\n",
-    "levels = np.linspace(-5, 5, 21)\n",
-    "contours = icepack.plot.tricontourf(\n",
-    "    θ, levels=levels, extend='both', axes=axes\n",
+    "colors = icepack.plot.tripcolor(\n",
+    "    θ, vmin=-5, vmax=+5, axes=axes\n",
     ")\n",
-    "fig.colorbar(contours)\n",
-    "plt.show(fig)"
+    "fig.colorbar(colors);"
    ]
   },
   {
@@ -553,12 +571,10 @@
     "u = inverse_solver.state\n",
     "fig, axes = subplots()\n",
     "δu = firedrake.interpolate((u - u_obs)**2/(2*σ**2), Q)\n",
-    "levels = np.linspace(0., 50., 51)\n",
-    "contours = icepack.plot.tricontourf(\n",
-    "    δu, levels=levels, cmap='Reds', extend='max', axes=axes\n",
+    "colors = icepack.plot.tripcolor(\n",
+    "    δu, vmin=0, vmax=50, cmap='Reds', axes=axes\n",
     ")\n",
-    "fig.colorbar(contours)\n",
-    "plt.show(fig)"
+    "fig.colorbar(colors);"
    ]
   },
   {

--- a/notebooks/tutorials/06-hybrid-ice-stream.ipynb
+++ b/notebooks/tutorials/06-hybrid-ice-stream.ipynb
@@ -86,7 +86,7 @@
    "source": [
     "V = firedrake.VectorFunctionSpace(\n",
     "    mesh, dim=2, family='CG', degree=2,\n",
-    "    vfamily='GL', vdegree=1\n",
+    "    vfamily='GL', vdegree=2\n",
     ")"
    ]
   },
@@ -518,11 +518,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "V_1 = firedrake.VectorFunctionSpace(\n",
+    "V_2 = firedrake.VectorFunctionSpace(\n",
     "    mesh, dim=2, family='CG', degree=2,\n",
-    "    vfamily='GL', vdegree=1\n",
+    "    vfamily='GL', vdegree=2\n",
     ")\n",
-    "u_1 = firedrake.interpolate(u, V_1)\n",
+    "u_2 = firedrake.interpolate(u, V_2)\n",
     "\n",
     "V_4 = firedrake.VectorFunctionSpace(\n",
     "    mesh, dim=2, family='CG', degree=2,\n",
@@ -557,7 +557,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "δu = firedrake.interpolate(u_4 - u_1, V_4)\n",
+    "δu = firedrake.interpolate(u_4 - u_2, V_4)\n",
     "print(firedrake.norm(δu) / firedrake.norm(u_4))"
    ]
   },

--- a/notebooks/tutorials/06-hybrid-ice-stream.ipynb
+++ b/notebooks/tutorials/06-hybrid-ice-stream.ipynb
@@ -1,18 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import tqdm\n",
-    "import matplotlib.pyplot as plt\n",
-    "import firedrake\n",
-    "import icepack, icepack.plot"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -51,6 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import firedrake\n",
     "Lx, Ly = 50e3, 12e3\n",
     "nx, ny = 48, 32\n",
     "mesh2d = firedrake.RectangleMesh(nx, ny, Lx, Ly)\n",
@@ -74,7 +63,7 @@
    "source": [
     "Q = firedrake.FunctionSpace(\n",
     "    mesh, family='CG', degree=2,\n",
-    "    vfamily='DG', vdegree=0\n",
+    "    vfamily='R', vdegree=0\n",
     ")"
    ]
   },
@@ -168,6 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import icepack\n",
     "T = firedrake.Constant(255.0)\n",
     "A = icepack.rate_factor(T)"
    ]
@@ -237,8 +227,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `tricontourf` function in icepack will detect whether you're trying to plot a 2D or a 3D field.\n",
-    "Plotting 3D fields is expensive, so as a default, this function will depth-average the input field and make a contour plot of the resulting 2D field."
+    "The plotting functions in icepack will detect whether you're trying to plot a 2D or a 3D field.\n",
+    "Plotting 3D fields is expensive, so as a default, this function will depth-average the input field and make a plot of the resulting 2D field."
    ]
   },
   {
@@ -247,10 +237,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import icepack.plot\n",
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(u0, 25, axes=axes)\n",
-    "fig.colorbar(contours, ax=axes, fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(u0, axes=axes)\n",
+    "fig.colorbar(colors, ax=axes, fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -268,10 +258,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import tqdm\n",
+    "\n",
     "num_years = 250\n",
     "timesteps_per_year = 2\n",
     "\n",
-    "δt = 1.0/timesteps_per_year\n",
+    "δt = 1.0 / timesteps_per_year\n",
     "num_timesteps = num_years * timesteps_per_year\n",
     "\n",
     "a = firedrake.interpolate(1.7 - 2.7 * x / Lx, Q)\n",
@@ -312,9 +304,8 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours =  icepack.plot.tricontourf(h, 25, axes=axes)\n",
-    "fig.colorbar(contours, label='meters', fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(h, axes=axes)\n",
+    "fig.colorbar(colors, label='meters', fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -324,9 +315,8 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(u, 25, axes=axes)\n",
-    "fig.colorbar(contours, label='meters/year', fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(u, axes=axes)\n",
+    "fig.colorbar(colors, label='meters/year', fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -340,9 +330,10 @@
     "\n",
     "f = firedrake.project(a - div_2(h * u), Q)\n",
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(f, 25, cmap='RdBu', axes=axes)\n",
-    "fig.colorbar(contours, label='meters/year', fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(\n",
+    "    f, vmin=-0.1, vmax=+0.1, cmap='RdBu', axes=axes\n",
+    ")\n",
+    "fig.colorbar(colors, label='meters/year', fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -352,6 +343,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
     "xs = np.array([(Lx * k / nx, 0, 0.5) for k in range(nx + 1)])\n",
     "\n",
     "ss = np.array(s.at(xs, tolerance=1e-10))\n",
@@ -363,8 +355,7 @@
     "axes.plot(xs[:, 0] / 1e3, ss - hs, color='blue')\n",
     "axes.plot(xs[:, 0] / 1e3, ss, color='blue')\n",
     "axes.set_xlabel('distance along centerline (km)')\n",
-    "axes.set_ylabel('elevation (m)')\n",
-    "plt.show(fig)"
+    "axes.set_ylabel('elevation (m)');"
    ]
   },
   {
@@ -376,8 +367,7 @@
     "fig, axes = plt.subplots()\n",
     "axes.plot(xs[:, 0] / 1e3, hs)\n",
     "axes.set_xlabel('distance along centerline (km)')\n",
-    "axes.set_ylabel('thickness (m)')\n",
-    "plt.show(fig)"
+    "axes.set_ylabel('thickness (m)');"
    ]
   },
   {
@@ -443,9 +433,8 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(u_shear, 25, axes=axes)\n",
-    "fig.colorbar(contours, label='meters/year', fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(u_shear, axes=axes)\n",
+    "fig.colorbar(colors, label='meters/year', fraction=0.012, pad=0.04);"
    ]
   },
   {
@@ -479,16 +468,15 @@
    "outputs": [],
    "source": [
     "fig, axes = icepack.plot.subplots()\n",
-    "contours = icepack.plot.tricontourf(ratio, 25, axes=axes)\n",
-    "fig.colorbar(contours, fraction=0.012, pad=0.04)\n",
-    "plt.show(fig)"
+    "colors = icepack.plot.tripcolor(ratio, axes=axes)\n",
+    "fig.colorbar(colors, fraction=0.012, pad=0.04);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The shear/plug ratio tops out at around 6\\%.\n",
+    "The shear/plug ratio tops out at around 7%.\n",
     "For comparison, when the vertical velocity profile follows the shallow ice approximation, the horizontal velocity is a quartic polynomial in the vertical:\n",
     "\n",
     "$$u \\propto 1 - (1 - \\zeta)^4.$$\n",
@@ -577,7 +565,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A mismatch of only 3\\% is not bad at all!\n",
+    "A mismatch of only 3% is not bad at all!\n",
     "However, if we used a synthetic glacier that were closer to the idealized shallow ice approximation then the error would be larger.\n",
     "The accuracy of the degree-1 solution in this particular case should not be extrapolated to all scenarios.\n",
     "\n",


### PR DESCRIPTION
This patch switches the tutorials to mostly using tripcolor instead of tricontour(f). Since tripcolor now defaults to Gouraud rather than flat shading, this is a much better option for most visualizations. I've also added a description of the kinds of bump and ramp functions that we use in all the synthetic glacier simulations to the 0th tutorial.