### PR TITLE
mesh refinement how-to guide

### DIFF
--- a/notebooks/how-to/03-adaptivity.ipynb
+++ b/notebooks/how-to/03-adaptivity.ipynb
@@ -1,0 +1,876 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Mesh refinement\n",
+    "\n",
+    "In this guide, we'll show how to adapt the spatial resolution for a simulation.\n",
+    "We'll again use the MISMIP+ test case to demonstrate on.\n",
+    "In the previous guides, we've focused solely on the spin-up phase of the MISMIP+ experiment.\n",
+    "The next phase is to see how the ice sheet responds to rapid melting near the grounding line, but capturing the spatial dependence of this melt function requires very high resolution.\n",
+    "We could uniformly refine the entire computational mesh, but then we'd be wasting loads of computing time getting very high resolution where we don't need it.\n",
+    "Instead, we'll use two simulations -- one with degree-1 basis functions and the other with degree-2 -- to assess where we're not adequately resolving the flow.\n",
+    "Then we'll use this error estimate to add more triangles where we're doing worst.\n",
+    "\n",
+    "### Geometry\n",
+    "\n",
+    "In the previous guides we've used either gmsh or one of the built-in Firedrake meshes to describe the geometry of our problem.\n",
+    "Here we'll instead use the mesh generator [Triangle](https://www.cs.cmu.edu/~quake/triangle.html) because it has a particularly simple interface for refinement.\n",
+    "Rather than generate the input files and call out to Triangle from the command line, we'll instead use a library interface to it from the Python package [MeshPy](https://documen.tician.de/meshpy/).\n",
+    "First, we'll fill a data structure describing the input to the mesh generator, which is particularly simple in this case."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from meshpy import triangle\n",
+    "\n",
+    "Lx, Ly = 640e3, 80e3\n",
+    "points = [\n",
+    "    (0, 0),\n",
+    "    (Lx, 0),\n",
+    "    (Lx, Ly),\n",
+    "    (0, Ly)\n",
+    "]\n",
+    "\n",
+    "facets = [(i, (i + 1) % len(points)) for i in range(len(points))]\n",
+    "markers = list(range(1, len(points) + 1))\n",
+    "\n",
+    "mesh_info = triangle.MeshInfo()\n",
+    "mesh_info.set_points(points)\n",
+    "mesh_info.set_facets(facets, facet_markers=markers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we built the mesh info data structure directly because the domain is so simple.\n",
+    "If you were instead starting from, say, a GeoJSON outline of a real glacier, which is likely to be much more complex, you could instead use the function `collection_to_triangle` in the `icepack.meshing` module.\n",
+    "That function is exactly analogous to `collection_to_geo`, which we've used before in order to talk to gmsh.\n",
+    "\n",
+    "Next we'll tell MeshPy to build an unstructured mesh.\n",
+    "In the previous guides we used a mesh edge length of 4km.\n",
+    "Triangle only offers a way to specify triangle areas rather than edge lengths, so we'll specify a maximum area of 8 km${}^2$.\n",
+    "We'll then use the helper function `triangle_to_firedrake` to convert the MeshPy data structure into a Firedrake mesh."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import icepack\n",
+    "δy = Ly / 10\n",
+    "area = δy**2 / 2\n",
+    "triangle_mesh = triangle.build(mesh_info, max_volume=area)\n",
+    "coarse_mesh = icepack.meshing.triangle_to_firedrake(triangle_mesh)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For all the visualizations in this demo, we'll plot everything with a 2-to-1 aspect ratio.\n",
+    "The domain is eight times longer than it is wide, so the scaling makes it easier to pick out important features in the solution.\n",
+    "These features might otherwise get obscured if we used a 1-to-1 aspect ratio."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import firedrake\n",
+    "import icepack.plot\n",
+    "\n",
+    "def subplots():\n",
+    "    fig, axes = icepack.plot.subplots()\n",
+    "    axes.set_aspect(2)\n",
+    "    axes.set_xlim((0, Lx))\n",
+    "    axes.set_ylim((0, Ly))\n",
+    "    return fig, axes\n",
+    "    \n",
+    "fig, axes = subplots()\n",
+    "firedrake.triplot(coarse_mesh, axes=axes)\n",
+    "axes.legend();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we'll see soon, the data structure from MeshPy gives us the freedom to refine triangles locally."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Input data\n",
+    "\n",
+    "We'll use the same bed topography as in the previous guides, but we'll have to recreate it on more than one mesh.\n",
+    "For that reason, it'll be handy to define a function that will create the bed topography for us."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firedrake import exp, max_value, Constant\n",
+    "def mismip_bed_topography(mesh):\n",
+    "    x, y = firedrake.SpatialCoordinate(mesh)\n",
+    "\n",
+    "    x_c = Constant(300e3)\n",
+    "    X = x / x_c\n",
+    "\n",
+    "    B_0 = Constant(-150)\n",
+    "    B_2 = Constant(-728.8)\n",
+    "    B_4 = Constant(343.91)\n",
+    "    B_6 = Constant(-50.57)\n",
+    "    B_x = B_0 + B_2 * X**2 + B_4 * X**4 + B_6 * X**6\n",
+    "\n",
+    "    f_c = Constant(4e3)\n",
+    "    d_c = Constant(500)\n",
+    "    w_c = Constant(24e3)\n",
+    "\n",
+    "    B_y = d_c * (\n",
+    "        1 / (1 + exp(-2 * (y - Ly / 2 - w_c) / f_c)) +\n",
+    "        1 / (1 + exp(+2 * (y - Ly / 2 + w_c) / f_c))\n",
+    "    )\n",
+    "\n",
+    "    z_deep = Constant(-720)\n",
+    "    return max_value(B_x + B_y, z_deep)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll use the same viscosity and friction values as the previous demos and the same friction law."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = Constant(20)\n",
+    "C = Constant(1e-2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firedrake import sqrt, inner\n",
+    "from icepack.constants import (\n",
+    "    ice_density as ρ_I,\n",
+    "    water_density as ρ_W,\n",
+    "    gravity as g,\n",
+    "    weertman_sliding_law as m\n",
+    ")\n",
+    "\n",
+    "def friction(**kwargs):\n",
+    "    variables = ('velocity', 'thickness', 'surface', 'friction')\n",
+    "    u, h, s, C = map(kwargs.get, variables)\n",
+    "\n",
+    "    p_W = ρ_W * g * max_value(0, -(s - h))\n",
+    "    p_I = ρ_I * g * h\n",
+    "    N = max_value(0, p_I - p_W)\n",
+    "    τ_c = N / 2\n",
+    "\n",
+    "    u_c = (τ_c / C)**m\n",
+    "    u_b = sqrt(inner(u, u))\n",
+    "\n",
+    "    return τ_c * (\n",
+    "        (u_c**(1/m + 1) + u_b**(1/m + 1))**(m / (m + 1)) - u_c\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll again use a constant accumulation rate of 30 cm/year, but in the second phase of the simulation we'll add melting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = Constant(0.3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll be using the same physics model throughout, despite the fact that the spatial domain and the discretization will change."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import icepack\n",
+    "model = icepack.models.IceStream(friction=friction)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### First run\n",
+    "\n",
+    "In order to get a better idea of where we need to refine the mesh, we'll start by looking at the results of relatively low-resolution simulations.\n",
+    "Since we'll be running the same simulation many times, we'll again wrap up the code in a function that we can call repeatedly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tqdm\n",
+    "from firedrake import dx\n",
+    "\n",
+    "def run_simulation(solver, time, dt, **fields):\n",
+    "    h, s, u, z_b = map(fields.get, ('thickness', 'surface', 'velocity', 'bed'))\n",
+    "    h_0 = h.copy(deepcopy=True)\n",
+    "    num_steps = int(final_time / dt)\n",
+    "    progress_bar = tqdm.trange(num_steps)\n",
+    "    for step in progress_bar:\n",
+    "        h = solver.prognostic_solve(\n",
+    "            dt,\n",
+    "            thickness=h,\n",
+    "            velocity=u,\n",
+    "            accumulation=a,\n",
+    "            thickness_inflow=h_0\n",
+    "        )\n",
+    "        h.interpolate(max_value(h, 1.0))\n",
+    "        s = icepack.compute_surface(thickness=h, bed=z_b)\n",
+    "\n",
+    "        u = solver.diagnostic_solve(\n",
+    "            velocity=u,\n",
+    "            thickness=h,\n",
+    "            surface=s,\n",
+    "            fluidity=A,\n",
+    "            friction=C\n",
+    "        )\n",
+    "\n",
+    "        min_h = h.dat.data_ro.min()\n",
+    "        avg_h = firedrake.assemble(h * dx) / (Lx * Ly)\n",
+    "        description = f\"avg, min h: {avg_h:4.2f}, {min_h:4.2f}\"\n",
+    "        progress_bar.set_description(description)\n",
+    "        \n",
+    "    return {'thickness': h, 'surface': s, 'velocity': u}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt = 5.0\n",
+    "final_time = 3600.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "opts = {\n",
+    "    'dirichlet_ids': [4],\n",
+    "    'side_wall_ids': [1, 3],\n",
+    "    'diagnostic_solver_type': 'icepack',\n",
+    "    'diagnostic_solver_parameters': {\n",
+    "        'ksp_type': 'preonly',\n",
+    "        'pc_type': 'lu',\n",
+    "        'pc_factor_mat_solver_type': 'mumps',\n",
+    "        'tolerance': 1e-8\n",
+    "    }\n",
+    "}\n",
+    "solver = icepack.solvers.FlowSolver(model, **opts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For our initial low-res simulation, we'll use the mesh above with piecewise linear finite elements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Q1 = firedrake.FunctionSpace(coarse_mesh, 'CG', 1)\n",
+    "V1 = firedrake.VectorFunctionSpace(coarse_mesh, 'CG', 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firedrake import as_vector, interpolate\n",
+    "z_b = interpolate(mismip_bed_topography(coarse_mesh), Q1)\n",
+    "h_0 = interpolate(Constant(100), Q1)\n",
+    "s_0 = icepack.compute_surface(thickness=h_0, bed=z_b)\n",
+    "\n",
+    "x = firedrake.SpatialCoordinate(coarse_mesh)[0]\n",
+    "u_0 = solver.diagnostic_solve(\n",
+    "    velocity=interpolate(as_vector((90 * x / Lx, 0)), V1),\n",
+    "    thickness=h_0,\n",
+    "    surface=s_0,\n",
+    "    fluidity=A,\n",
+    "    friction=C\n",
+    ")\n",
+    "\n",
+    "fields = {\n",
+    "    'surface': s_0,\n",
+    "    'thickness': h_0,\n",
+    "    'velocity': u_0\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fields_1 = run_simulation(\n",
+    "    solver, final_time, dt, bed=z_b, **fields\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We were able to compute the results fairly fast, but the coarse mesh resolution is very obvious in the plot of the solution below.\n",
+    "There are clearly spurious artifacts in the shear margins at the top and bottom of the domain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def colorbar(fig, colors):\n",
+    "    return fig.colorbar(colors, fraction=0.012, pad=0.025)\n",
+    "\n",
+    "fig, axes = subplots()\n",
+    "colors = firedrake.tripcolor(fields_1['thickness'], axes=axes)\n",
+    "colorbar(fig, colors);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we'll repeat the same simulation again at higher resolution by using piecewise quadratic instead of piecewise linear basis functions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Q2 = firedrake.FunctionSpace(coarse_mesh, 'CG', 2)\n",
+    "V2 = firedrake.VectorFunctionSpace(coarse_mesh, 'CG', 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z_b = interpolate(mismip_bed_topography(coarse_mesh), Q2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h_0 = interpolate(Constant(100), Q2)\n",
+    "s_0 = icepack.compute_surface(thickness=h_0, bed=z_b)\n",
+    "\n",
+    "x = firedrake.SpatialCoordinate(coarse_mesh)[0]\n",
+    "solver = icepack.solvers.FlowSolver(model, **opts)\n",
+    "u_0 = solver.diagnostic_solve(\n",
+    "    velocity=interpolate(as_vector((90 * x / Lx, 0)), V2),\n",
+    "    thickness=h_0,\n",
+    "    surface=s_0,\n",
+    "    fluidity=A,\n",
+    "    friction=C\n",
+    ")\n",
+    "\n",
+    "fields = {\n",
+    "    'thickness': h_0,\n",
+    "    'surface': s_0,\n",
+    "    'velocity': u_0\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fields_2 = run_simulation(\n",
+    "    solver, final_time, dt, bed=z_b, **fields\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To get an idea of where we're making the largest errors, we can look at the discrepancy between the degree-1 and degree-2 simulations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expr = abs(fields_2['thickness'] - fields_1['thickness'])\n",
+    "δh = interpolate(expr, Q2)\n",
+    "\n",
+    "fig, axes = subplots()\n",
+    "colors = firedrake.tripcolor(δh, axes=axes)\n",
+    "colorbar(fig, colors);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Perhaps not surprisingly, the biggest misfits occur near the grounding line.\n",
+    "Now that we know where we need more triangles, how do we go about refining the mesh?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Refinement\n",
+    "\n",
+    "Before actually refining the mesh, we'll want to create a new field that smooths over the thickness error in space.\n",
+    "This will help give a more continuous gradation between coarse and fine triangles rather than a sudden jump."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firedrake import dS\n",
+    "\n",
+    "DG0 = firedrake.FunctionSpace(coarse_mesh, 'DG', 0)\n",
+    "ϵ = firedrake.Function(DG0)\n",
+    "J = 0.5 * (\n",
+    "    (ϵ - δh)**2 * dx +\n",
+    "    (Ly / 2) * (ϵ('+') - ϵ('-'))**2 * dS\n",
+    ")\n",
+    "F = firedrake.derivative(J, ϵ)\n",
+    "firedrake.solve(F == 0, ϵ)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = subplots()\n",
+    "colors = firedrake.tripcolor(ϵ, axes=axes)\n",
+    "colorbar(fig, colors);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `element_volumes` member of the Triangle mesh data structure contains an array that we'll fill in order to specify the desired triangle areas in the refined mesh.\n",
+    "This array isn't initialized by default.\n",
+    "The setup routine below allocates space for it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "triangle_mesh.element_volumes.setup()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we have to make some decisions about how much to actually refine the mesh.\n",
+    "Here we'll specify arbitrarily that the triangles with the largest errors will have their areas shrunk by a factor of 8.\n",
+    "We then have to decide how much to shrink the areas of triangles with less than the largest error.\n",
+    "The scaling could be linear, or quadratic, or the square root -- this is up to us.\n",
+    "For this problem, we'll use a quadratic scaling; this makes for fewer triangles than if we had used linear scaling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expr = firedrake.CellVolume(coarse_mesh)\n",
+    "areas = firedrake.project(expr, DG0)\n",
+    "\n",
+    "shrink = 8\n",
+    "exponent = 2\n",
+    "max_err = ϵ.dat.data_ro[:].max()\n",
+    "\n",
+    "num_triangles = len(triangle_mesh.elements)\n",
+    "for index, err in enumerate(ϵ.dat.data_ro[:]):\n",
+    "    area = areas.dat.data_ro[index]\n",
+    "    shrink_factor = shrink * (err / max_err)**exponent\n",
+    "    triangle_mesh.element_volumes[index] = area / (1 + shrink_factor)\n",
+    "    \n",
+    "refined_triangle_mesh = triangle.refine(triangle_mesh)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once again we'll use the convenience function `triangle_to_firedrake` to convert the Triangle data structure into a Firedrake data structure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fine_mesh = icepack.meshing.triangle_to_firedrake(refined_triangle_mesh)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The figure below shows approximate position of the grounding line on the old mesh, overlaid on top of the new mesh.\n",
+    "We've zoomed in on part of the domain so you can see how much more refined the mesh is in the neighborhood of the grounding line."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = icepack.plot.subplots()\n",
+    "axes.set_xlim((350e3, 550e3))\n",
+    "axes.set_ylim((0, 80e3))\n",
+    "axes.get_yaxis().set_visible(False)\n",
+    "\n",
+    "s = fields_2['surface']\n",
+    "h = fields_2['thickness']\n",
+    "height_above_flotation = interpolate(s - (1 - ρ_I / ρ_W) * h, Q2)\n",
+    "levels = [0, 1, 10]\n",
+    "contours = icepack.plot.tricontour(\n",
+    "    height_above_flotation, levels=levels, axes=axes\n",
+    ")\n",
+    "\n",
+    "firedrake.triplot(fine_mesh, axes=axes);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Second run\n",
+    "\n",
+    "Now that we have a refined mesh, we can project our old solutions on the coarse mesh to it and run the physics out for a further several thousand years to get even closer to the equilibrium solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Q1 = firedrake.FunctionSpace(fine_mesh, 'CG', 1)\n",
+    "V1 = firedrake.VectorFunctionSpace(fine_mesh, 'CG', 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h_0 = firedrake.project(fields_2['thickness'], Q1)\n",
+    "u_0 = firedrake.project(fields_2['velocity'], V1)\n",
+    "\n",
+    "z_b = interpolate(mismip_bed_topography(fine_mesh), Q1)\n",
+    "s_0 = icepack.compute_surface(thickness=h_0, bed=z_b)\n",
+    "\n",
+    "opts = {\n",
+    "    'dirichlet_ids': [4],\n",
+    "    'side_wall_ids': [1, 3],\n",
+    "    'diagnostic_solver_type': 'petsc',\n",
+    "    'diagnostic_solver_parameters': {\n",
+    "        'snes_type': 'newtontr',\n",
+    "        'snes_max_it': 100,\n",
+    "        'ksp_type': 'preonly',\n",
+    "        'pc_type': 'lu',\n",
+    "        'pc_factor_mat_solver_type': 'mumps'\n",
+    "    }\n",
+    "}\n",
+    "solver = icepack.solvers.FlowSolver(model, **opts)\n",
+    "u_0 = solver.diagnostic_solve(\n",
+    "    velocity=u_0,\n",
+    "    thickness=h_0,\n",
+    "    surface=s_0,\n",
+    "    fluidity=A,\n",
+    "    friction=C\n",
+    ")\n",
+    "\n",
+    "fields = {\n",
+    "    'surface': s_0,\n",
+    "    'thickness': h_0,\n",
+    "    'velocity': u_0\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "final_time = 900.0\n",
+    "dt = 1.0\n",
+    "fields_1 = run_simulation(\n",
+    "    solver, final_time, dt, bed=z_b, **fields\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now for the higher-resolution run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Q2 = firedrake.FunctionSpace(fine_mesh, 'CG', 2)\n",
+    "V2 = firedrake.VectorFunctionSpace(fine_mesh, 'CG', 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h_0 = firedrake.project(fields_2['thickness'], Q2)\n",
+    "u_0 = firedrake.project(fields_2['velocity'], V2)\n",
+    "\n",
+    "z_b = interpolate(mismip_bed_topography(fine_mesh), Q1)\n",
+    "s_0 = icepack.compute_surface(thickness=h_0, bed=z_b)\n",
+    "\n",
+    "opts = {\n",
+    "    'dirichlet_ids': [4],\n",
+    "    'side_wall_ids': [1, 3],\n",
+    "    'diagnostic_solver_type': 'petsc',\n",
+    "    'diagnostic_solver_parameters': {\n",
+    "        'snes_type': 'newtontr',\n",
+    "        'snes_max_it': 100,\n",
+    "        'ksp_type': 'preonly',\n",
+    "        'pc_type': 'lu',\n",
+    "        'pc_factor_mat_solver_type': 'mumps'\n",
+    "    }\n",
+    "}\n",
+    "solver = icepack.solvers.FlowSolver(model, **opts)\n",
+    "u_0 = solver.diagnostic_solve(\n",
+    "    velocity=u_0,\n",
+    "    thickness=h_0,\n",
+    "    surface=s_0,\n",
+    "    fluidity=A,\n",
+    "    friction=C\n",
+    ")\n",
+    "\n",
+    "fields = {\n",
+    "    'surface': s_0,\n",
+    "    'thickness': h_0,\n",
+    "    'velocity': u_0\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fields_2 = run_simulation(\n",
+    "    solver, final_time, dt, bed=z_b, **fields\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And finally we can look at the results.\n",
+    "The first thing to notice is that the discrepancies between the high- and the low-resolution runs are much reduced now that we've refined the mesh."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expr = fields_2['thickness'] - fields_1['thickness']\n",
+    "δh = interpolate(abs(expr), Q2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = subplots()\n",
+    "colors = firedrake.tripcolor(δh, axes=axes)\n",
+    "colorbar(fig, colors);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we can look at a plot of the thickness itself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = subplots()\n",
+    "colors = firedrake.tripcolor(fields_2['thickness'], axes=axes)\n",
+    "colorbar(fig, colors);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The runs on the coarse mesh showed obvious grid-imprinting artifacts in the shear margins.\n",
+    "While the results aren't perfect on the higher-resolution mesh, things are now much improved."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Conclusion\n",
+    "\n",
+    "The code that we've shown above demonstrates how to refine the mesh according to criteria of your choosing.\n",
+    "We used an interface to Triangle through the package MeshPy to do that, but first we had to do two things:\n",
+    "\n",
+    "1. **Estimate the errors.**\n",
+    "We used the discrepancy in thickness between a lower and a higher-order finite element basis as a proxy for the true error, which we cannot know.\n",
+    "2. **Decide how much to refine the mesh and where.**\n",
+    "We came up with a completely arbitrary area scaling formula through trial and error.\n",
+    "It happened to work ok.\n",
+    "\n",
+    "There are alternative approaches for each of these steps.\n",
+    "Another common method for error estimation is to measure the *gradient reconstruction* error.\n",
+    "If we used, say, a continuous piecewise quadratic basis for the thickness, its gradient would be a discontinuous field.\n",
+    "The idea of gradient reconstruction is to project the discontinuous, exact value of the gradient field back onto the basis CG(2) that we used in the first place.\n",
+    "The discrepancy between the exact gradient and the reconstruction tells us something about the error.\n",
+    "This is only one approach and there are many more ways to do *a posteriori error estimation*.\n",
+    "\n",
+    "To make a more informed decision about where to refine the mesh, we can try to equally distribute the error according to the estimate we've already obtained above.\n",
+    "We could also have guessed that we'll need lots of triangles near the glacier grounding line before we went to solve anything.\n",
+    "In that case, we're using specific domain knowledge about the problem rather than a posteriori error estimates.\n",
+    "This is also a good idea and you can always use a posteriori error estimates to guide further refinements.\n",
+    "\n",
+    "There is a more scientific way to approach a posteriori error estimation and mesh refinement based on finding the derivative of a certain *goal functional* -- which plays a similar role to the objective functional in an inverse problem -- with respect to the state variables.\n",
+    "If you want to learn more, the book by [Bangerth and Rannacher](https://doi.org/10.1007/978-3-0348-7605-6) is a great reference.\n",
+    "\n",
+    "In this demonstration, we used only a single cycle of simulate, estimate, refine, simulate again.\n",
+    "You can of course repeat the loop more than once to add further refinement levels.\n",
+    "You can also apply the same principles to decide how to adapatively choose the timestep -- rather than use a single time integration loop, run a low-res simulation with timestep $\\delta t$ and a high-res one with timestep $\\delta t / 2$.\n",
+    "The approach we've shown here is pretty rudimentary and leaves a lot up to you.\n",
+    "Using these ideas can be a huge help in solving practical problems, but it requires a lot of experimentation."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "firedrake",
+   "language": "python",
+   "name": "firedrake"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_data={'icepack': ['registry.txt']},
     install_requires=['numpy', 'scipy', 'matplotlib', 'rasterio>=1.0.26',
                       'netCDF4', 'geojson', 'shapely', 'pooch>=1.0.0',
-                      'pygmsh<=6.1.1', 'meshio>=3.3.1', 'tqdm'],
+                      'pygmsh<=6.1.1', 'meshio>=3.3.1', 'MeshPy', 'tqdm'],
     extras_require = {
         'doc': ['sphinx', 'ipykernel', 'nbconvert', 'nikola']
     }

--- a/test/meshing_test.py
+++ b/test/meshing_test.py
@@ -66,3 +66,17 @@ def test_converting_to_geo(tmpdir, input_data):
     collection = input_data()
     geometry = icepack.meshing.collection_to_geo(collection, lcar=1e-2)
     assert geometry.get_code() is not None
+
+
+@pytest.mark.parametrize('input_data', test_data)
+def test_converting_to_triangle(input_data):
+    collection = input_data()
+    lcar = 1e-1
+    geometry = icepack.meshing.collection_to_triangle(
+        collection, max_volume=0.5 * lcar**2
+    )
+    assert len(geometry.elements) > 0
+
+    mesh = icepack.meshing.triangle_to_firedrake(geometry)
+    assert mesh.num_vertices() > 0
+    assert mesh.num_cells() > 0


### PR DESCRIPTION
Resolves #53 although not by the method suggested there. I had tried to implement r-refinement as described in that issue but wasn't able to write a solver for the Monge-Ampere equations that worked very well. Instead, this patch adds some glue code to talk to MeshPy, which in turn provides an interface to the mesh generator Triangle. Triangle makes it simple to take an initial mesh and specify the desired triangle areas for a refined mesh. This is possible but much more cumbersome with gmsh. I've also added a how-to guide that shows how to do adaptive refinement using MISMIP+ as a test case.