### PR TITLE
Refactor vector calculus operators

### DIFF
--- a/icepack/calculus.py
+++ b/icepack/calculus.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2020-2021 by Daniel Shapero <shapero@uw.edu> and Benjamin Hills
+# <benjaminhhills@gmail.com>
+#
+# This file is part of icepack.
+#
+# icepack is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# The full text of the license can be found in the file LICENSE in the
+# icepack source directory or at <http://www.gnu.org/licenses/>.
+
+r"""Vector calculus operators that dispatch on the dimension of the underlying mesh
+
+This module includes functions for calculating things like the gradient or divergence
+of a field in a way that does what you mean whether the underlying geometry is a plan-
+view, flowband, or 3D model.
+"""
+
+import firedrake
+
+
+def get_mesh_axes(mesh):
+    r"""Get a string representing the axes present in the mesh -- 'x', 'xy', 'xz', or
+    'xyz'"""
+    mesh_dim = mesh.geometric_dimension()
+    extruded = mesh.layers is not None
+    if mesh_dim == 1:
+        return "x"
+    if mesh_dim == 2 and extruded:
+        return "xz"
+    if mesh_dim == 2 and not extruded:
+        return "xy"
+    if mesh_dim == 3 and extruded:
+        return "xyz"
+
+    raise ValueError("icepack requires 3D meshes to be extruded")
+
+
+def grad(q):
+    r"""Compute the gradient of a scalar or vector field"""
+    axes = get_mesh_axes(q.ufl_domain())
+    if axes == "xy":
+        return firedrake.grad(q)
+    if axes == "xyz":
+        return firedrake.as_tensor((q.dx(0), q.dx(1)))
+    return q.dx(0)
+
+
+def sym_grad(u):
+    r"""Compute the symmetric gradient of a vector field"""
+    axes = get_mesh_axes(u.ufl_domain())
+    if axes == "xy":
+        return firedrake.sym(firedrake.grad(u))
+    if axes == "xyz":
+        return firedrake.sym(firedrake.as_tensor((u.dx(0), u.dx(1))))
+    return u.dx(0)
+
+
+def div(u):
+    r"""Compute the horizontal divergence of a velocity field"""
+    axes = get_mesh_axes(u.ufl_domain())
+    if axes == "xy":
+        return firedrake.div(u)
+    if axes == "xyz":
+        return u[0].dx(0) + u[1].dx(1)
+    return u.dx(0)
+
+
+def FacetNormal(mesh):
+    r"""Compute the horizontal component of the unit outward normal vector to a mesh"""
+    axes = get_mesh_axes(mesh)
+    ν = firedrake.FacetNormal(mesh)
+    if axes == "xy":
+        return ν
+    if axes == "xyz":
+        return firedrake.as_vector((ν[0], ν[1]))
+    return ν[0]
+
+
+def trace(A):
+    r"""Compute the trace of a rank-2 tensor"""
+    axes = get_mesh_axes(A.ufl_domain())
+    if axes in ["x", "xz"]:
+        return A
+    return firedrake.tr(A)
+
+
+def Identity(dim):
+    r"""Return the unit tensor of a given dimension"""
+    if dim == 1:
+        return firedrake.Constant(1.0)
+    return firedrake.Identity(dim)

--- a/icepack/models/damage_transport.py
+++ b/icepack/models/damage_transport.py
@@ -21,7 +21,6 @@ from operator import itemgetter
 import firedrake
 from firedrake import (
     inner,
-    grad,
     div,
     dx,
     ds,

--- a/icepack/models/friction.py
+++ b/icepack/models/friction.py
@@ -14,7 +14,8 @@ from operator import itemgetter
 import firedrake
 from firedrake import inner, sqrt
 from icepack.constants import weertman_sliding_law as m
-from icepack.utilities import facet_normal_nd, diameter
+from icepack.utilities import diameter
+from icepack.calculus import FacetNormal
 
 
 def friction_stress(u, C):
@@ -57,9 +58,7 @@ def side_friction(**kwargs):
     u, h = itemgetter("velocity", "thickness")(kwargs)
     Cs = kwargs.get("side_friction", firedrake.Constant(0.0))
 
-    mesh = u.ufl_domain()
-    ν = facet_normal_nd(mesh)
-
+    ν = FacetNormal(u.ufl_domain())
     u_t = u - inner(u, ν) * ν
     τ = friction_stress(u_t, Cs)
     return -m / (m + 1) * h * inner(τ, u_t)
@@ -77,8 +76,7 @@ def normal_flow_penalty(**kwargs):
     scale = kwargs.get("scale", firedrake.Constant(1.0))
 
     mesh = u.ufl_domain()
-    ν = facet_normal_nd(mesh)
-
+    ν = FacetNormal(mesh)
     L = diameter(mesh)
     δx = firedrake.FacetArea(mesh)
 

--- a/icepack/models/heat_transport.py
+++ b/icepack/models/heat_transport.py
@@ -20,7 +20,7 @@ from icepack.constants import (
     latent_heat as L,
     melting_temperature as Tm,
 )
-from icepack.utilities import facet_normal_nd
+from icepack.calculus import FacetNormal
 
 
 class HeatTransport3D:
@@ -58,11 +58,13 @@ class HeatTransport3D:
         Q = E.function_space()
         ψ = firedrake.TestFunction(Q)
 
+        # NOTE: Be careful here going to xz! You might have to separate this into
+        # the sum of a horizontal and vertical flux if we're shadowing Firedrake's
+        # grad operator with out own specialized one.
         U = firedrake.as_vector((u[0], u[1], w))
         flux_cells = -E * inner(U, grad(ψ)) * h * dx
 
-        mesh = Q.mesh()
-        ν = facet_normal_nd(mesh)
+        ν = FacetNormal(Q.mesh())
         outflow = firedrake.max_value(inner(u, ν), 0)
         inflow = firedrake.min_value(inner(u, ν), 0)
 

--- a/icepack/models/ice_shelf.py
+++ b/icepack/models/ice_shelf.py
@@ -17,7 +17,6 @@ from icepack.constants import ice_density as ρ_I, water_density as ρ_W, gravit
 from icepack.models.viscosity import viscosity_depth_averaged as viscosity
 from icepack.models.friction import side_friction, normal_flow_penalty
 from icepack.models.mass_transport import Continuity
-from icepack.optimization import MinimizationProblem, NewtonSolver
 from icepack.utilities import add_kwarg_wrapper
 
 

--- a/icepack/models/mass_transport.py
+++ b/icepack/models/mass_transport.py
@@ -22,7 +22,7 @@ manner consistent with the bed elevation and where the ice may go afloat.
 from operator import itemgetter
 import firedrake
 from firedrake import dx, inner
-from icepack import utilities
+from icepack.calculus import grad, FacetNormal
 
 
 class Continuity:
@@ -36,11 +36,9 @@ class Continuity:
         Q = h.function_space()
         q = firedrake.TestFunction(Q)
 
-        grad, ds, n = (
-            utilities.grad_nd,
-            utilities.ds_nd(q),
-            utilities.facet_normal_nd(Q.mesh()),
-        )
+        mesh = Q.mesh()
+        n = FacetNormal(mesh)
+        ds = firedrake.ds if mesh.layers is None else firedrake.ds_v
 
         u_n = inner(u, n)
         flux_cells = -inner(h * u, grad(q)) * dx

--- a/icepack/models/shallow_ice.py
+++ b/icepack/models/shallow_ice.py
@@ -45,7 +45,8 @@ def gravity(**kwargs):
     The gravity function for the shallow ice action functional is
 
     .. math::
-        E(u) = \int_\Omega\frac{2A(\varrho_I g)**n}{n+2} (\nabla h^2\cdot u) h^{n+1} \nabla s^{n-1}\; dx
+        E(u) = \int_\Omega\frac{2A(\varrho_I g)**n}{n+2} (\nabla h^2\cdot u)
+        h^{n+1} \nabla s^{n-1}\; dx
 
     Parameters
     ----------

--- a/icepack/utilities.py
+++ b/icepack/utilities.py
@@ -28,64 +28,6 @@ default_solver_parameters = {
 }
 
 
-def get_mesh_dimensions(mesh):
-    r"""Get the number of dimensions in the mesh. Half dimensions for extruded into the vertical."""
-    mesh_dim = mesh.geometric_dimension()
-    if mesh_dim == 1 and mesh.layers is None:
-        return "x"
-    elif mesh_dim == 2 and mesh.layers is not None:
-        return "xz"
-    elif mesh_dim == 2 and mesh.layers is None:
-        return "xy"
-    elif mesh_dim == 3 and mesh.layers is not None:
-        return "xyz"
-    else:
-        raise ValueError("icepack is not compatible with mesh dimension: %s" % mesh_dim)
-
-
-def facet_normal_nd(mesh):
-    r"""Compute the horizontal component of the unit outward normal vector
-    to a mesh"""
-    dim = get_mesh_dimensions(mesh)
-    if dim == "xy":
-        return firedrake.FacetNormal(mesh)
-    elif dim == "xyz":
-        ν = firedrake.FacetNormal(mesh)
-        return firedrake.as_vector((ν[0], ν[1]))
-    else:
-        return firedrake.FacetNormal(mesh)[0]
-
-
-def grad_nd(q):
-    r"""Compute the horizontal gradient of a 3D field"""
-    dim = get_mesh_dimensions(q.ufl_domain())
-    if dim == "xy":
-        return firedrake.grad(q)
-    elif dim == "xyz":
-        return firedrake.as_tensor((q.dx(0), q.dx(1)))
-    else:
-        return q.dx(0)
-
-
-def div_nd(q):
-    r"""Compute the horizontal divergence of a 3D field"""
-    dim = get_mesh_dimensions(q.ufl_domain())
-    if dim == "xy":
-        return firedrake.div(q)
-    elif dim == "xyz":
-        return q[0].dx(0) + q[1].dx(1)
-    else:
-        return q.dx(0)
-
-
-def ds_nd(q):
-    dim = get_mesh_dimensions(q.ufl_domain())
-    if dim in ["x", "xy"]:
-        return firedrake.ds
-    else:
-        return firedrake.ds_v
-
-
 def eigenvalues(a):
     r"""Return a pair of symbolic expressions for the largest and smallest
     eigenvalues of a 2D rank-2 tensor"""


### PR DESCRIPTION
This patch pulls all of the specialized vector calculus operators that @benhills added to support flowband models into their own module. I also added functions for the trace of a matrix and to create the Identity matrix. This makes it possible to get rid of the conditionals in the definition of the viscous action for both depth-averaged or 3D models.