### PR TITLE
Container version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
 jobs:
   python36:
     docker:
-      - image: icepack/firedrake-python3.6:0.5.1
+      - image: icepack/firedrake-python3.6:0.5.2
     working_directory: ~/icepack
     steps:
       - build
@@ -32,7 +32,7 @@ jobs:
       - realtest
   python38:
     docker:
-      - image: icepack/firedrake-python3.8:0.5.1
+      - image: icepack/firedrake-python3.8:0.5.2
     working_directory: ~/icepack
     steps:
       - build

--- a/notebooks/tutorials/03-larsen-ice-shelf.ipynb
+++ b/notebooks/tutorials/03-larsen-ice-shelf.ipynb
@@ -51,7 +51,7 @@
    "outputs": [],
    "source": [
     "import icepack\n",
-    "outline_filename = icepack.datasets.fetch_larsen_outline()\n",
+    "outline_filename = icepack.datasets.fetch_outline('larsen')\n",
     "print(outline_filename)"
    ]
   },

--- a/notebooks/tutorials/05-ice-shelf-inverse.ipynb
+++ b/notebooks/tutorials/05-ice-shelf-inverse.ipynb
@@ -66,7 +66,7 @@
     "import geojson\n",
     "import icepack\n",
     "\n",
-    "outline_filename = icepack.datasets.fetch_larsen_outline()\n",
+    "outline_filename = icepack.datasets.fetch_outline('larsen')\n",
     "with open(outline_filename, 'r') as outline_file:\n",
     "    outline = geojson.load(outline_file)\n",
     "    \n",


### PR DESCRIPTION
Use a new version of the testing image with fixes to Firedrake for the warnings about wrapping the entire numpy random number generator API. Also eliminate the use of some old deprecated functions.