### PR TITLE
Bump container version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
 jobs:
   python36:
     docker:
-      - image: icepack/firedrake-python3.6:0.5.2
+      - image: icepack/firedrake-python3.6:0.5.3
     working_directory: ~/icepack
     steps:
       - build
@@ -32,7 +32,7 @@ jobs:
       - realtest
   python38:
     docker:
-      - image: icepack/firedrake-python3.8:0.5.2
+      - image: icepack/firedrake-python3.8:0.5.3
     working_directory: ~/icepack
     steps:
       - build


### PR DESCRIPTION
Gets us to a Firedrake version after the loopy sprint, exchanging one set of warnings for another.