### PR TITLE
Move quadrature degree estimation from solver to models

### DIFF
--- a/icepack/solvers/flow_solver.py
+++ b/icepack/solvers/flow_solver.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 by Daniel Shapero <shapero@uw.edu>
+# Copyright (C) 2020-2021 by Daniel Shapero <shapero@uw.edu>
 #
 # This file is part of icepack.
 #
@@ -255,9 +255,7 @@ class PETScSolver:
         action = self._model.action(**self._fields, **_kwargs)
         F = firedrake.derivative(action, u)
 
-        degree = self._model.quadrature_degree(**self._fields)
-        params = {"form_compiler_parameters": {"quadrature_degree": degree}}
-        problem = firedrake.NonlinearVariationalProblem(F, u, bcs, **params)
+        problem = firedrake.NonlinearVariationalProblem(F, u, bcs)
         self._solver = firedrake.NonlinearVariationalSolver(
             problem, solver_parameters=self._solver_parameters
         )


### PR DESCRIPTION
Before, quadrature degree setting occured inside FlowSolver. This has the unfortunate effect of leaving the firedrake-adjoint with no way to know what quadrature degree to use, barring upstream fixes. The solver for the adjoint equation then uses the default, conservative quadrature estimation, resulting in annoying warnings and low performance. This patch puts quadrature degree in by adding it to the metadata of all the measures (dx, ds, etc.) in the action functionals.