### PR TITLE
Make error messages more informative

### DIFF
--- a/icepack/solvers/damage_solver.py
+++ b/icepack/solvers/damage_solver.py
@@ -48,7 +48,10 @@ class DamageSolver:
                 elif isinstance(field, firedrake.Function):
                     self._fields[name] = field.copy(deepcopy=True)
                 else:
-                    raise TypeError("Input fields must be Constant or Function!")
+                    raise TypeError(
+                        "Input %s field has type %s, must be Constant or Function!"
+                        % (name, type(field))
+                    )
 
         # Create symbolic representations of the flux and sources of damage
         dt = firedrake.Constant(1.0)

--- a/icepack/solvers/flow_solver.py
+++ b/icepack/solvers/flow_solver.py
@@ -167,7 +167,10 @@ class IcepackSolver:
                 elif isinstance(field, firedrake.Function):
                     self._fields[name] = field.copy(deepcopy=True)
                 else:
-                    raise TypeError("Input fields must be Constant or Function!")
+                    raise TypeError(
+                        "Input %s field has type %s, must be Constant or Function!"
+                        % (name, type(field))
+                    )
 
         # Create homogeneous BCs for the Dirichlet part of the boundary
         u = self._fields["velocity"]
@@ -236,7 +239,10 @@ class PETScSolver:
                 elif isinstance(field, firedrake.Function):
                     self._fields[name] = field.copy(deepcopy=True)
                 else:
-                    raise TypeError("Input fields must be Constant or Function!")
+                    raise TypeError(
+                        "Input %s field has type %s, must be Constant or Function!"
+                        % (name, type(field))
+                    )
 
         # Create homogeneous BCs for the Dirichlet part of the boundary
         u = self._fields["velocity"]
@@ -299,7 +305,10 @@ class ImplicitEuler:
                 elif isinstance(field, firedrake.Function):
                     self._fields[name] = field.copy(deepcopy=True)
                 else:
-                    raise TypeError("Input fields must be Constant or Function!")
+                    raise TypeError(
+                        "Input %s field has type %s, must be Constant or Function!"
+                        % (name, type(field))
+                    )
 
         dt = firedrake.Constant(1.0)
         dh_dt = self._continuity(dt, **self._fields)
@@ -356,7 +365,10 @@ class LaxWendroff:
                 elif isinstance(field, firedrake.Function):
                     self._fields[name] = field.copy(deepcopy=True)
                 else:
-                    raise TypeError("Input fields must be Constant or Function!")
+                    raise TypeError(
+                        "Input %s field has type %s, must be Constant or Function!"
+                        % (name, type(field))
+                    )
 
         dt = firedrake.Constant(1.0)
         h = self._fields["thickness"]

--- a/icepack/solvers/heat_transport.py
+++ b/icepack/solvers/heat_transport.py
@@ -45,7 +45,10 @@ class HeatTransportSolver:
                 elif isinstance(field, firedrake.Function):
                     self._fields[name] = field.copy(deepcopy=True)
                 else:
-                    raise TypeError("Input fields must be Constant or Function!")
+                    raise TypeError(
+                        "Input %s field has type %s, must be Constant or Function!"
+                        % (name, type(field))
+                    )
 
         dt = Constant(1.0)
 


### PR DESCRIPTION
Resolves #72. The error message now prints out the offending field and what type it does have. @jabadge are there other cryptic error messages we should fix up?