### PR TITLE
Time-dependent adjoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,13 +18,13 @@ commands:
       - run: codecov
   styletest:
     steps:
-      - run: pip3 install black
+      - run: pip3 install black==21.12b0
       - run: black --check ./
 
 jobs:
   python36:
     docker:
-      - image: icepack/firedrake-python3.6:0.5.5
+      - image: icepack/firedrake-python3.6:0.5.7
     working_directory: ~/icepack
     steps:
       - build
@@ -32,7 +32,7 @@ jobs:
       - realtest
   python38:
     docker:
-      - image: icepack/firedrake-python3.8:0.5.5
+      - image: icepack/firedrake-python3.8:0.5.7
     working_directory: ~/icepack
     steps:
       - build

--- a/icepack/__init__.py
+++ b/icepack/__init__.py
@@ -19,6 +19,7 @@ import icepack.datasets
 import icepack.models
 import icepack.solvers
 import icepack.inverse
+import icepack.statistics
 
 __all__ = [
     "norm",
@@ -32,4 +33,5 @@ __all__ = [
     "models",
     "solvers",
     "inverse",
+    "statistics",
 ]

--- a/icepack/statistics.py
+++ b/icepack/statistics.py
@@ -1,0 +1,194 @@
+# Copyright (C) 2022 by Daniel Shapero <shapero@uw.edu>
+#
+# This file is part of icepack.
+#
+# icepack is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# The full text of the license can be found in the file LICENSE in the
+# icepack source directory or at <http://www.gnu.org/licenses/>.
+
+from copy import deepcopy
+import firedrake
+from firedrake import assemble
+import pyadjoint, pyadjoint.optimization.rol_solver
+
+
+class StatisticsProblem:
+    def __init__(self, simulation, loss_functional, regularization, controls):
+        r"""Initialize a data assimilation problem
+
+        Parameters
+        ----------
+        simulation
+            A function that takes in the controls and returns the observables
+        loss_functional
+            A function that takes in the observables returns a form that can be
+            assembled to produce the value of the model-data misfit, i.e. the
+            negative logarithm of the likelihood function
+        regularization
+            A function that takes in the controls and returns a form that can
+            be assembled to produce the value of the regularization, i.e. the
+            negative log prior
+        controls
+            An initial guess for the unknown state or parameters; can be either
+            a Firedrake Function or Constant, or an iterable of Functions or
+            Constants
+        """
+        self._simulation = simulation
+        self._loss_functional = loss_functional
+        self._regularization = regularization
+        if isinstance(controls, (firedrake.Function, firedrake.Constant)):
+            self._controls = controls.copy(deepcopy=True)
+        else:
+            self._controls = [field.copy(deepcopy=True) for field in controls]
+
+    @property
+    def simulation(self):
+        return self._simulation
+
+    @property
+    def loss_functional(self):
+        return self._loss_functional
+
+    @property
+    def regularization(self):
+        return self._regularization
+
+    @property
+    def controls(self):
+        return self._controls
+
+
+class _ROLObjectiveWrapper(pyadjoint.optimization.rol_solver.ROLObjective):
+    def __init__(self, *args, **kwargs):
+        r"""Wrapper around the ROL objective functional class that returns
+        infinity if the forward solver crashes"""
+        super(_ROLObjectiveWrapper, self).__init__(*args, **kwargs)
+
+    def update(self, x, flag, iteration):
+        try:
+            self.val = self.rf(x.dat)
+        except firedrake.ConvergenceError:
+            self.val = np.inf
+
+
+class _ROLSolverWrapper(pyadjoint.ROLSolver):
+    def __init__(self, problem, controls, inner_product="L2"):
+        r"""Wrapper around the ROL solver class that uses the patched Objective
+        class"""
+        super(_ROLSolverWrapper, self).__init__(
+            problem, controls, inner_product=inner_product
+        )
+        self.rolobjective = _ROLObjectiveWrapper(problem.reduced_functional)
+
+
+_default_rol_options = {
+    "Step": {
+        "Type": "Trust Region",
+        "Trust Region": {
+            "Initial Radius": -1,
+            "Subproblem Solver": "Truncated CG",
+            "Radius Growing Rate": 2.5,
+            "Step Acceptance Threshold": 0.05,
+            "Radius Shrinking Threshold": 0.05,
+            "Radius Growing Threshold": 0.9,
+            "Radius Shrinking Rate (Negative rho)": 0.0625,
+            "Radius Shrinking Rate (Positive rho)": 0.25,
+            "Sufficient Decrease Parameter": 1e-4,
+            "Safeguard Size": 1e2,
+        },
+    },
+    "Status Test": {
+        "Gradient Tolerance": 1e-4,
+        "Step Tolerance": 5e-3,
+        "Iteration Limit": 50,
+    },
+    "General": {
+        "Print Verbosity": 0,
+        "Secant": {},
+    },
+}
+
+
+class MaximumProbabilityEstimator:
+    def __init__(self, problem, solver_type="rol", **kwargs):
+        r"""Estimates the true value of the controls by computing the maximizer
+        of the posterior probability distribution"""
+        from firedrake_adjoint import Control, ReducedFunctional
+
+        self._problem = problem
+        if isinstance(problem.controls, (firedrake.Function, firedrake.Constant)):
+            self._controls = problem.controls.copy(deepcopy=True)
+        else:
+            self._controls = [field.copy(deepcopy=True) for field in problem.controls]
+
+        # Form the objective functional
+        self._state = self.problem.simulation(self.controls)
+        self._loss_functional = self.problem.loss_functional(self.state)
+        self._regularization = self.problem.regularization(self.controls)
+        J = assemble(self._loss_functional) + assemble(self._regularization)
+
+        if isinstance(self.controls, (firedrake.Function, firedrake.Constant)):
+            reduced_objective = ReducedFunctional(J, Control(self.controls))
+        else:
+            controls = [Control(field) for field in self.controls]
+            reduced_objective = ReducedFunctional(J, controls)
+
+        # Form the minimization problem and solver
+        if isinstance(solver_type, str) and solver_type.lower() == "rol":
+            problem_wrapper = pyadjoint.MinimizationProblem(reduced_objective)
+
+            if "rol_options" in kwargs.keys():
+                options = kwargs["rol_options"]
+            else:
+                options = deepcopy(_default_rol_options)
+
+                # A bunch of glue code to talk to ROL. We want to use our own
+                # keyword argument names in the event that we start using a
+                # different optimization package like TAO on the backend, so
+                # here we're translating between our names and ROL's.
+                test = options["Status Test"]
+                test["Step Tolerance"] = kwargs.get("step_tolerance", 5e-3)
+                test["Gradient Tolerance"] = kwargs.get("gradient_tolerance", 1e-4)
+                test["Iteration Limit"] = kwargs.get("max_iterations", 50)
+
+                general = options["General"]
+                general["Print Verbosity"] = int(kwargs.get("verbose", False))
+
+                # Use the Newton trust region algorithm if we can compute the
+                # second derivative of the objective and BFGS if we can't.
+                algorithm = kwargs.get("algorithm", "trust-region")
+                if algorithm == "bfgs":
+                    options["Step"] = {
+                        "Type": "Line Search",
+                        "Line Search": {
+                            "Descent Method": {"Type": "Quasi-Newton Step"}
+                        },
+                    }
+                    memory = kwargs.get("memory", 10)
+                    general["Secant"] = {
+                        "Type": "Limited-Memory BFGS",
+                        "Maximum Storage": memory,
+                    }
+
+            self._solver = _ROLSolverWrapper(problem_wrapper, options)
+        else:
+            raise NotImplementedError("Only ROL solver implemented for now!")
+
+    @property
+    def problem(self):
+        return self._problem
+
+    @property
+    def controls(self):
+        return self._controls
+
+    @property
+    def state(self):
+        return self._state
+
+    def solve(self):
+        return self._solver.solve()

--- a/notebooks/how-to/04-sparse-data.ipynb
+++ b/notebooks/how-to/04-sparse-data.ipynb
@@ -1,0 +1,654 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Assimilating sparse data\n",
+    "\n",
+    "In this demo, we'll look again at estimating the fluidity coefficient $A$ in Glen's flow law\n",
+    "\n",
+    "$$\\dot\\varepsilon = A\\tau^3$$\n",
+    "\n",
+    "from observational data for the Larsen Ice Shelf.\n",
+    "The [previous tutorial](https://icepack.github.io/notebooks/tutorials/05-ice-shelf-inverse/) showed how to solve statistical estimation problems when we can assume that the measured data $u^o$ are a continuous field defined throughout our entire domain.\n",
+    "In that setting the model-data misfit functional is\n",
+    "\n",
+    "$$E(u) = \\int_\\Omega\\frac{|u - u^o|^2}{2\\sigma^2}dx.$$\n",
+    "\n",
+    "In this demo, we'll instead focus on *sparse* measurements -- the observations are defined at a set of isolated points $\\{x_k\\}$, and the model-data misfit functional is\n",
+    "\n",
+    "$$E(u) = \\sum_k\\frac{|u(x_k) - u^o_k|^2}{2\\sigma_k^2}.$$\n",
+    "\n",
+    "Assembling and differentiating functionals that include pointwise evaluation, alongside the usual continuous operations like taking a gradient or integrating over the whole spatial domain, is relatively uncommon in finite element modeling packages.\n",
+    "Firedrake is the only such package that natively supports defining functionals that involve evaluating a state variable at a discrete point set.\n",
+    "Moreover, the ability to evaluate at a discrete point set composes nicely with the automatic differentiation features, so we can use it in optimization problems just like before.\n",
+    "\n",
+    "We'll again use the reparameterization trick of inferring the field $\\theta$ in\n",
+    "\n",
+    "$$A = A_0e^\\theta$$\n",
+    "\n",
+    "in order to guarantee that the fluidity coefficient is positive.\n",
+    "We'll also use the same regularization functional as before:\n",
+    "\n",
+    "$$R(\\theta) = \\frac{L^2}{2\\Theta^2}\\int_\\Omega|\\nabla \\theta|^2dx.$$\n",
+    "\n",
+    "In all other respects, the problem will be identical to the previous tutorial."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Input data\n",
+    "\n",
+    "The input data are the same as from the previous demo on inferring the fluidity of the Larsen Ice Shelf."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess\n",
+    "import geojson\n",
+    "import firedrake\n",
+    "import icepack\n",
+    "\n",
+    "outline_filename = icepack.datasets.fetch_outline(\"larsen\")\n",
+    "with open(outline_filename, \"r\") as outline_file:\n",
+    "    outline = geojson.load(outline_file)\n",
+    "\n",
+    "geometry = icepack.meshing.collection_to_geo(outline)\n",
+    "with open(\"larsen.geo\", \"w\") as geo_file:\n",
+    "    geo_file.write(geometry.get_code())\n",
+    "    \n",
+    "command = \"gmsh -2 -format msh2 -v 2 -o larsen.msh larsen.geo\"\n",
+    "subprocess.run(command.split())\n",
+    "mesh = firedrake.Mesh(\"larsen.msh\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The code below is the same boilerplate as in the previous tutorial for plotting simulation results on top of the mosaic of Antarctica image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import rasterio\n",
+    "import icepack.plot\n",
+    "\n",
+    "coords = np.array(list(geojson.utils.coords(outline)))\n",
+    "δ = 5e3\n",
+    "xmin, xmax = coords[:, 0].min() - δ, coords[:, 0].max() + δ\n",
+    "ymin, ymax = coords[:, 1].min() - δ, coords[:, 1].max() + δ\n",
+    "\n",
+    "image_filename = icepack.datasets.fetch_mosaic_of_antarctica()\n",
+    "with rasterio.open(image_filename, \"r\") as image_file:\n",
+    "    image_window = rasterio.windows.from_bounds(\n",
+    "        left=xmin,\n",
+    "        bottom=ymin,\n",
+    "        right=xmax,\n",
+    "        top=ymax,\n",
+    "        width=image_file.width,\n",
+    "        height=image_file.height,\n",
+    "        transform=image_file.transform,\n",
+    "    )\n",
+    "    image = image_file.read(indexes=1, window=image_window, masked=True)\n",
+    "\n",
+    "\n",
+    "def subplots(*args, **kwargs):\n",
+    "    fig, axes = icepack.plot.subplots(*args, **kwargs)\n",
+    "    xmin, ymin, xmax, ymax = rasterio.windows.bounds(image_window, image_file.transform)\n",
+    "    kw = {\n",
+    "        \"extent\": (xmin, xmax, ymin, ymax),\n",
+    "        \"cmap\": \"Greys_r\",\n",
+    "        \"vmin\": 12e3,\n",
+    "        \"vmax\": 16.38e3,\n",
+    "    }\n",
+    "    try:\n",
+    "        axes.imshow(image, **kw)\n",
+    "    except AttributeError:\n",
+    "        for ax in axes:\n",
+    "            ax.imshow(image, **kw)\n",
+    "\n",
+    "    return fig, axes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = subplots()\n",
+    "axes.set_xlabel(\"meters\")\n",
+    "kwargs = {\"interior_kw\": {\"linewidth\": 0.25}, \"boundary_kw\": {\"linewidth\": 2}}\n",
+    "icepack.plot.triplot(mesh, axes=axes, **kwargs)\n",
+    "axes.legend();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just like in the previous demos, we'll apply a smoothing filter to the thickness, which is necessary to get a reasonable driving stress."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from firedrake import assemble, Constant, inner, grad, dx\n",
+    "\n",
+    "thickness_filename = icepack.datasets.fetch_bedmachine_antarctica()\n",
+    "thickness = rasterio.open(f\"netcdf:{thickness_filename}:thickness\", \"r\")\n",
+    "\n",
+    "Q = firedrake.FunctionSpace(mesh, family=\"CG\", degree=2)\n",
+    "h0 = icepack.interpolate(thickness, Q)\n",
+    "\n",
+    "h = h0.copy(deepcopy=True)\n",
+    "α = Constant(2e3)\n",
+    "J = 0.5 * ((h - h0) ** 2 + α ** 2 * inner(grad(h), grad(h))) * dx\n",
+    "F = firedrake.derivative(J, h)\n",
+    "firedrake.solve(F == 0, h)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Point data\n",
+    "\n",
+    "Before, we were able to just interpolate the gridded data directly from rasterio datasets to the finite element spaces we were using for the velocity.\n",
+    "We're going to have to do a bit more work now that we want to work with the point data directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "velocity_filename = icepack.datasets.fetch_measures_antarctica()\n",
+    "vx_file = rasterio.open(f\"netcdf:{velocity_filename}:VX\", \"r\")\n",
+    "vy_file = rasterio.open(f\"netcdf:{velocity_filename}:VY\", \"r\")\n",
+    "stdx_file = rasterio.open(f\"netcdf:{velocity_filename}:ERRX\", \"r\")\n",
+    "stdy_file = rasterio.open(f\"netcdf:{velocity_filename}:ERRY\", \"r\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For starters, we'll want to create window objects around the observational data just like we did for reading the mosaic of Antarctica image.\n",
+    "The windowed transform of the original data will help us to find which points in the raw data are contained inside the mesh."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "window = rasterio.windows.from_bounds(\n",
+    "    left=xmin,\n",
+    "    bottom=ymin,\n",
+    "    right=xmax,\n",
+    "    top=ymax,\n",
+    "    width=vx_file.width,\n",
+    "    height=vx_file.height,\n",
+    "    transform=vx_file.transform,\n",
+    ").round_lengths().round_offsets()\n",
+    "transform = vx_file.window_transform(window)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just so you can get an idea of how dense the data are, the plot below zooms in on part of the shelf near the Gipps Ice Rise.\n",
+    "The data points are shown in orange and the mesh triangles in black; in this region, there are about 10-15 data points in each triangle.\n",
+    "In other regions, the mesh is much finer or coarser and so the data density could be different."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = np.array(\n",
+    "    [\n",
+    "        transform * (i, j)\n",
+    "        for i in range(window.width)\n",
+    "        for j in range(window.height)\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "fig, axes = subplots()\n",
+    "firedrake.triplot(mesh, axes=axes, interior_kw={\"linewidth\": 0.25})\n",
+    "axes.set_xlim((-2.07e6, -2.06e6))\n",
+    "axes.set_ylim((1.135e6, 1.145e6))\n",
+    "axes.scatter(xs[:, 0], xs[:, 1], 4.0, \"tab:orange\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we'll use the `locate_cell` method of the mesh to determine which points of the gridded data set are inside the computational domain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indices = np.array(\n",
+    "    [\n",
+    "        (i, j)\n",
+    "        for i in range(window.width)\n",
+    "        for j in range(window.height)\n",
+    "        if mesh.locate_cell(transform * (i, j))\n",
+    "    ]\n",
+    ")\n",
+    "xs = np.array([transform * idx for idx in indices])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The object that represents this point set from the Firedrake side is called `VertexOnlyMesh`.\n",
+    "To create a vertex-only mesh, we need to supply the background domain and the coordinates of the point cloud.\n",
+    "This step can take some time because there are a lot of points to go through; under the hood, Firedrake is looking through the background mesh to find which triangle each point lives in.\n",
+    "\n",
+    "We're also passing an extra argument to make sure that creating the vertex-only mesh will crash in the event that one of the input points is outside of the domain.\n",
+    "This extra flag isn't necessary in our case because we've already made sure that all the points are inside the domain, but it's helpful to know about this flag for debugging later if, say, the sizes of the arrays don't match up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "point_set = firedrake.VertexOnlyMesh(mesh, xs, missing_points_behaviour=\"error\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can create function spaces defined on this point set just like we make function spaces defined on triangular meshes.\n",
+    "We're specifying the element family as \"DG\" for discontinuous Galerkin, but strictly speaking this doesn't really matter -- on a point cloud, continuous and discontinuous Galerkin representations are the same."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Δ = firedrake.FunctionSpace(point_set, \"DG\", 0)\n",
+    "\n",
+    "u_o = firedrake.Function(Δ)\n",
+    "v_o = firedrake.Function(Δ)\n",
+    "σ_x = firedrake.Function(Δ)\n",
+    "σ_y = firedrake.Function(Δ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To fill these functions, we'll extract the values at the right indices of the gridded data and stuff them into the raw data array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vx = vx_file.read(indexes=1, window=window)\n",
+    "vy = vy_file.read(indexes=1, window=window)\n",
+    "stdx = stdx_file.read(indexes=1, window=window)\n",
+    "stdy = stdy_file.read(indexes=1, window=window)\n",
+    "\n",
+    "u_o.dat.data[:] = vx[indices[:, 1], indices[:, 0]]\n",
+    "v_o.dat.data[:] = vy[indices[:, 1], indices[:, 0]]\n",
+    "σ_x.dat.data[:] = stdx[indices[:, 1], indices[:, 0]]\n",
+    "σ_y.dat.data[:] = stdy[indices[:, 1], indices[:, 0]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we'll make an initial guess for the ice velocity by interpolating the gridded data to the triangular mesh."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "V = firedrake.VectorFunctionSpace(mesh, \"CG\", 2)\n",
+    "u_initial = icepack.interpolate((vx_file, vy_file), V)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We need to make an initial guess for the fluidity parameter.\n",
+    "In this case, we'll use the same value as in the second demo -- a constant fluidity assuming a temperature of -13C."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "T = Constant(260)\n",
+    "A0 = icepack.rate_factor(T)\n",
+    "\n",
+    "\n",
+    "def viscosity(**kwargs):\n",
+    "    u = kwargs[\"velocity\"]\n",
+    "    h = kwargs[\"thickness\"]\n",
+    "    θ = kwargs[\"log_fluidity\"]\n",
+    "\n",
+    "    A = A0 * firedrake.exp(θ)\n",
+    "    return icepack.models.viscosity.viscosity_depth_averaged(\n",
+    "        velocity=u, thickness=h, fluidity=A\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "model = icepack.models.IceShelf(viscosity=viscosity)\n",
+    "opts = {\n",
+    "    \"dirichlet_ids\": [2, 4, 5, 6, 7, 8, 9],\n",
+    "    \"diagnostic_solver_type\": \"petsc\",\n",
+    "    \"diagnostic_solver_parameters\": {\n",
+    "        \"snes_type\": \"newtontr\",\n",
+    "        \"ksp_type\": \"gmres\",\n",
+    "        \"pc_type\": \"lu\",\n",
+    "        \"pc_factor_mat_solver_type\": \"mumps\",\n",
+    "    },\n",
+    "}\n",
+    "solver = icepack.solvers.FlowSolver(model, **opts)\n",
+    "\n",
+    "θ = firedrake.Function(Q)\n",
+    "u = solver.diagnostic_solve(\n",
+    "    velocity=u_initial,\n",
+    "    thickness=h,\n",
+    "    log_fluidity=θ,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the computed of the ice velocity starting from our assumption that the fluidity is constant in space."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = subplots()\n",
+    "kwargs = {\"precision\": 1000, \"density\": 2500, \"vmin\": 0, \"vmax\": 750}\n",
+    "icepack.plot.streamplot(u, axes=axes, **kwargs);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's start with a taste of what comes next: interpolating this computed velocity to the vertex only mesh and evaluating the model-data misfit.\n",
+    "The real work is happening here in the two calls to `interpolate` right at the beginning of this cell.\n",
+    "The `interpolate` method can do more than just interpolate an algebraic expression into a finite element space -- it can also interpolate a Function defined on one mesh to a Function defined on a point cloud."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "u_interp = firedrake.interpolate(u[0], Δ)\n",
+    "v_interp = firedrake.interpolate(u[1], Δ)\n",
+    "\n",
+    "square_error = (u_interp - u_o) ** 2 / σ_x ** 2 + (v_interp - v_o) ** 2 / σ_y ** 2\n",
+    "\n",
+    "N = len(indices)\n",
+    "initial_misfit = assemble(0.5 * square_error * dx) / N\n",
+    "print(initial_misfit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To sum up expressions over the point cloud, we use the `assemble` function and the measure `dx` just like we do on ordinary triangular meshes!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Inferring the fluidity\n",
+    "\n",
+    "There are four parts that go into an inverse problem:\n",
+    "\n",
+    "* a physics model\n",
+    "* an initial guess for the parameter and state\n",
+    "* an error metric\n",
+    "* a smoothness metric\n",
+    "\n",
+    "We already have the physics model and some initial guesses.\n",
+    "The physics are wrapped up in the Python function `simulation` defined below; we'll pass this function when we create the inverse problem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def simulation(θ):\n",
+    "    return solver.diagnostic_solve(velocity=u_initial, thickness=h, log_fluidity=θ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since the ice shelf is so large, we're going to want to scale some of our output quantities of interest by the area of the shelf.\n",
+    "This will make everything into nice dimensionless numbers, rather than on the order of $10{}^{10}$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "area = assemble(Constant(1.0) * dx(mesh))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next step is to write a pair of Python functions that will create the model-data misfit functional and the regularization functional.\n",
+    "In the previous demo on inverse problems, we scaled both of these quantities by the area of the domain in order to get nice dimensionless quantities.\n",
+    "Here the loss functional isn't an area integral -- it's a sum over discrete points.\n",
+    "Instead, we'll divide by the number of observations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def loss_functional(u):\n",
+    "    u_interp = firedrake.interpolate(u[0], Δ)\n",
+    "    v_interp = firedrake.interpolate(u[1], Δ)\n",
+    "    δu, δv = u_interp - u_o, v_interp - v_o\n",
+    "    return 0.5 / Constant(N) * ((δu / σ_x) ** 2 + (δv / σ_y) ** 2) * dx\n",
+    "\n",
+    "\n",
+    "def regularization(θ):\n",
+    "    Θ = Constant(1.)\n",
+    "    L = Constant(7.5e3)\n",
+    "    return 0.5 / Constant(area) * (L / Θ)**2 * inner(grad(θ), grad(θ)) * dx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we'll create create a `StatisticsProblem` object.\n",
+    "To specify the problem, we need to give it a procedure for running the simulation, another procedure for evaluating how good our guess is, and an initial guess for the unknown parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from icepack.statistics import StatisticsProblem, MaximumProbabilityEstimator\n",
+    "\n",
+    "problem = StatisticsProblem(\n",
+    "    simulation=simulation,\n",
+    "    loss_functional=loss_functional,\n",
+    "    regularization=regularization,\n",
+    "    controls=θ,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we've specified the problem, we'll create a `MaximumProbabilityEstimator` to look for a solution.\n",
+    "The runtime is about the same as in the previous demo, so feel free to put on a fresh pot of coffee."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimator = MaximumProbabilityEstimator(\n",
+    "    problem,\n",
+    "    gradient_tolerance=1e-4,\n",
+    "    step_tolerance=1e-1,\n",
+    "    max_iterations=50,\n",
+    ")\n",
+    "θ = estimator.solve()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As before, the algorithm reduces the objective by two orders of magnitude by the time it's converged.\n",
+    "The computed log-fluidity field looks very similar to the one obtained when we matched the computed velocity to the field obtained by interpolating the observations to the mesh."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = subplots()\n",
+    "colors = icepack.plot.tripcolor(θ, vmin=-5, vmax=+5, axes=axes)\n",
+    "fig.colorbar(colors);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Conclusion\n",
+    "\n",
+    "The results we obtained from assimilating the point data directly were mostly similar to those we obtained from interpolating them to the finite element mesh.\n",
+    "Why go through the exercise at all?\n",
+    "\n",
+    "One of the advantages of assimilating sparse point data directly is that we can be more rigorous about the statistical interpretation of our results.\n",
+    "If we assume that the observational data are normally distributed about the true velocity values with mean 0 and with standard deviation as reported in the remote sensing product, then the sum of squared errors is a $\\chi^2$ random variable with $N - M$ degrees of freedom, where $N$ is the number of observation points and $M$ is the number of degrees of freedom of the parameters we're fitting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "u = simulation(θ)\n",
+    "χ_2 = assemble(loss_functional(u))\n",
+    "print(χ_2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By using the point data directly, we know exactly what $N$ is, which isn't true at all when we're comparing to a velocity that's been interpolated to a mesh that could have a more or less arbitrary and variable resolution.\n",
+    "We still have the problem of determining the number $M$ of degrees of freedom, which is a little more involved because of the regularization; we have to read it off from the trace of the posterior covariance matrix.\n",
+    "That's outside the scope of this tutorial, but we could also have, for example, used a few eigenfunctions of the Laplace operator as a fixed set of basis functions with no regularization instead.\n",
+    "In any case, using the raw data gets us closer to a statistical exactitude.\n",
+    "If we can't fit our model to observations as well as we expect, that suggests either that we've mis-characterized the statistical properties of the observations or that our model is incorrect.\n",
+    "\n",
+    "The second key advantage was not apparent in this notebook but does show up in other applications.\n",
+    "Here we used a gridded data product with fairly dense coverage over the domain of interest.\n",
+    "Other data sources are genuinely sparse, for example laser altimetry measurements from ICESat-2, radar sounding from Operation IceBridge flights, or even strain gauge or thermometry data from isolated boreholes."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "firedrake",
+   "language": "python",
+   "name": "firedrake"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/how-to/05-time-dependent-inverse.ipynb
+++ b/notebooks/how-to/05-time-dependent-inverse.ipynb
@@ -1,0 +1,639 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Time-dependent data assimilation\n",
+    "\n",
+    "**Warning:** the code demonstrated in this notebook is experimental.\n",
+    "Use it at your own risk.\n",
+    "We had to tweak solver choices and settings in order to make it work.\n",
+    "If you try to build off of it and something breaks, please [get in touch](https://icepack.github.io/contact/).\n",
+    "\n",
+    "This notebook will demonstrate some more of the capabilities that icepack has for assimilating observational data.\n",
+    "In a previous demo, we showed how to estimate a parameter in an ice model (the fluidity) from remote sensing observations.\n",
+    "To do so, we had to specify:\n",
+    "\n",
+    "1. the loss functional, or how we measure the agreement of our computed state with observations\n",
+    "2. the regularization functional, or how unusual or complex our guess for these parameters were, and\n",
+    "3. the simulation, or what the physics is that relates the parameters and the observable fields.\n",
+    "\n",
+    "In the previous demo, the governing physics was the momentum conservation equation of ice flow, which is time-independent.\n",
+    "Here we'll look at how to use more involved simulations, including both mass and momentum conservation, that relate the unknown and the observable fields.\n",
+    "The resulting simulation now depends on time.\n",
+    "This is possible thanks to the adjoint capabilities in Firedrake and it looks pretty similar to the simpler time-dependent case.\n",
+    "\n",
+    "Rather than try to estimate an unobservable parameter as we did in the previous demo, we'll focus here on estimating the value of an initial condition from measurements of the glacier at a later time.\n",
+    "In principle, you can do joint estimation of both state and parameters at once; as far as the code is concerned, there's no distinction between the two.\n",
+    "We've stuck to a pure state estimation problem here just to keep things simple."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setup\n",
+    "\n",
+    "We'll start from the MISMIP+ geometry and steady state from the previous notebooks.\n",
+    "Computing the steady state of the MISMIP+ test case is expensive.\n",
+    "Rather than do a cold start every time, we'll instead load up a previously-computed steady state from checkpoint files if they're available.\n",
+    "(See the [how-to guide](https://icepack.github.io/notebooks/how-to/02-checkpointing/) on checkpointing.)\n",
+    "If not, we'll do an initial spin-up for 3600 years using a cheaper degree-1 finite element basis and then a final spin-up using a degree-2 basis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import firedrake\n",
+    "from firedrake import (\n",
+    "    exp,\n",
+    "    sqrt,\n",
+    "    inner,\n",
+    "    as_vector,\n",
+    "    grad,\n",
+    "    max_value,\n",
+    "    Constant,\n",
+    "    interpolate,\n",
+    "    dx,\n",
+    ")\n",
+    "\n",
+    "Lx, Ly = 640e3, 80e3\n",
+    "ny = 20\n",
+    "nx = int(Lx / Ly) * ny\n",
+    "area = Constant(Lx * Ly)\n",
+    "\n",
+    "mesh = firedrake.RectangleMesh(nx, ny, Lx, Ly)\n",
+    "Q1 = firedrake.FunctionSpace(mesh, family=\"CG\", degree=1)\n",
+    "V1 = firedrake.VectorFunctionSpace(mesh, family=\"CG\", degree=1)\n",
+    "Q2 = firedrake.FunctionSpace(mesh, family=\"CG\", degree=2)\n",
+    "V2 = firedrake.VectorFunctionSpace(mesh, family=\"CG\", degree=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mismip_bed(mesh):\n",
+    "    x, y = firedrake.SpatialCoordinate(mesh)\n",
+    "\n",
+    "    x_c = Constant(300e3)\n",
+    "    X = x / x_c\n",
+    "\n",
+    "    B_0 = Constant(-150)\n",
+    "    B_2 = Constant(-728.8)\n",
+    "    B_4 = Constant(343.91)\n",
+    "    B_6 = Constant(-50.57)\n",
+    "    B_x = B_0 + B_2 * X ** 2 + B_4 * X ** 4 + B_6 * X ** 6\n",
+    "\n",
+    "    f_c = Constant(4e3)\n",
+    "    d_c = Constant(500)\n",
+    "    w_c = Constant(24e3)\n",
+    "\n",
+    "    B_y = d_c * (\n",
+    "        1 / (1 + exp(-2 * (y - Ly / 2 - w_c) / f_c)) +\n",
+    "        1 / (1 + exp(+2 * (y - Ly / 2 + w_c) / f_c))\n",
+    "    )\n",
+    "\n",
+    "    z_deep = Constant(-720)\n",
+    "\n",
+    "    return max_value(B_x + B_y, z_deep)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = Constant(20)\n",
+    "C = Constant(1e-2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll use the Schoof-type friction law from before rather than the Weertman sliding law."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from icepack.constants import (\n",
+    "    ice_density as ρ_I,\n",
+    "    water_density as ρ_W,\n",
+    "    gravity as g,\n",
+    "    weertman_sliding_law as m,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def friction(**kwargs):\n",
+    "    variables = (\"velocity\", \"thickness\", \"surface\", \"friction\")\n",
+    "    u, h, s, C = map(kwargs.get, variables)\n",
+    "\n",
+    "    p_W = ρ_W * g * max_value(0, -(s - h))\n",
+    "    p_I = ρ_I * g * h\n",
+    "    N = max_value(0, p_I - p_W)\n",
+    "    τ_c = N / 2\n",
+    "\n",
+    "    u_c = (τ_c / C) ** m\n",
+    "    u_b = sqrt(inner(u, u))\n",
+    "\n",
+    "    return τ_c * ((u_c ** (1 / m + 1) + u_b ** (1 / m + 1)) ** (m / (m + 1)) - u_c)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a_0 = Constant(0.3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import icepack\n",
+    "model = icepack.models.IceStream(friction=friction)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tqdm\n",
+    "\n",
+    "\n",
+    "def run_simulation(solver, h, s, u, z_b, final_time, dt):\n",
+    "    h_in = Constant(100.0)\n",
+    "    a = interpolate(a_0, h.function_space())\n",
+    "\n",
+    "    num_steps = int(final_time / dt)\n",
+    "    for step in tqdm.trange(num_steps):\n",
+    "        h = solver.prognostic_solve(\n",
+    "            dt,\n",
+    "            thickness=h,\n",
+    "            velocity=u,\n",
+    "            accumulation=a,\n",
+    "            thickness_inflow=h_in,\n",
+    "        )\n",
+    "        s = icepack.compute_surface(thickness=h, bed=z_b)\n",
+    "\n",
+    "        u = solver.diagnostic_solve(\n",
+    "            velocity=u,\n",
+    "            thickness=h,\n",
+    "            surface=s,\n",
+    "            fluidity=A,\n",
+    "            friction=C,\n",
+    "        )\n",
+    "\n",
+    "    return h, s, u"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "opts = {\n",
+    "    \"dirichlet_ids\": [1],\n",
+    "    \"side_wall_ids\": [3, 4],\n",
+    "    \"diagnostic_solver_type\": \"petsc\",\n",
+    "    \"diagnostic_solver_parameters\": {\n",
+    "        \"snes_type\": \"newtontr\",\n",
+    "        \"ksp_type\": \"preonly\",\n",
+    "        \"pc_type\": \"lu\",\n",
+    "        \"pc_factor_mat_solver_type\": \"mumps\",\n",
+    "    },\n",
+    "    \"prognostic_solver_parameters\": {\n",
+    "        \"ksp_type\": \"gmres\",\n",
+    "        \"pc_type\": \"ilu\",\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load in the steady state of the system, computed with degree-1 elements, from checkpoint files if it exists.\n",
+    "Recreate the steady state from a cold start if not."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if os.path.exists(\"mismip-degree1.h5\"):\n",
+    "    h_1 = firedrake.Function(Q1)\n",
+    "    s_1 = firedrake.Function(Q1)\n",
+    "    u_1 = firedrake.Function(V1)\n",
+    "\n",
+    "    with firedrake.DumbCheckpoint(\"mismip-degree1\", mode=firedrake.FILE_READ) as chk:\n",
+    "        chk.load(h_1, name=\"thickness\")\n",
+    "        chk.load(s_1, name=\"surface\")\n",
+    "        chk.load(u_1, name=\"velocity\")\n",
+    "else:\n",
+    "    z_b = interpolate(mismip_bed(mesh), Q1)\n",
+    "    h_0 = interpolate(Constant(100), Q1)\n",
+    "    s_0 = icepack.compute_surface(thickness=h_0, bed=z_b)\n",
+    "\n",
+    "    flow_solver = icepack.solvers.FlowSolver(model, **opts)\n",
+    "    x = firedrake.SpatialCoordinate(mesh)[0]\n",
+    "    u_0 = flow_solver.diagnostic_solve(\n",
+    "        velocity=interpolate(as_vector((90 * x / Lx, 0)), V1),\n",
+    "        thickness=h_0,\n",
+    "        surface=s_0,\n",
+    "        fluidity=A,\n",
+    "        friction=C,\n",
+    "    )\n",
+    "\n",
+    "    dt = 5.0\n",
+    "    final_time = 3600\n",
+    "\n",
+    "    h_1, s_1, u_1 = run_simulation(flow_solver, h_0, s_0, u_0, z_b, final_time, dt)\n",
+    "\n",
+    "    with firedrake.DumbCheckpoint(\"mismip-degree1\", mode=firedrake.FILE_CREATE) as chk:\n",
+    "        chk.store(h_1, name=\"thickness\")\n",
+    "        chk.store(s_1, name=\"surface\")\n",
+    "        chk.store(u_1, name=\"velocity\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load in the steady state computed with degree-2 elements from a file if it exists, or spin it up from the degree-1 solution if not."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flow_solver = icepack.solvers.FlowSolver(model, **opts)\n",
+    "z_b = interpolate(mismip_bed(mesh), Q2)\n",
+    "\n",
+    "if os.path.exists(\"mismip-degree2.h5\"):\n",
+    "    h = firedrake.Function(Q2)\n",
+    "    s = firedrake.Function(Q2)\n",
+    "    u = firedrake.Function(V2)\n",
+    "\n",
+    "    with firedrake.DumbCheckpoint(\"mismip-degree2\", mode=firedrake.FILE_READ) as chk:\n",
+    "        chk.load(h, name=\"thickness\")\n",
+    "        chk.load(s, name=\"surface\")\n",
+    "        chk.load(u, name=\"velocity\")\n",
+    "else:\n",
+    "    h = interpolate(h_1, Q2)\n",
+    "    s = interpolate(s_1, Q2)\n",
+    "    u = interpolate(u_1, V2)\n",
+    "\n",
+    "    final_time = 3600\n",
+    "    dt = 4.0\n",
+    "\n",
+    "    h, s, u = run_simulation(flow_solver, h, s, u, z_b, final_time, dt)\n",
+    "\n",
+    "    with firedrake.DumbCheckpoint(\"mismip-degree2\", mode=firedrake.FILE_CREATE) as chk:\n",
+    "        chk.store(h, name=\"thickness\")\n",
+    "        chk.store(s, name=\"surface\")\n",
+    "        chk.store(u, name=\"velocity\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Simulation\n",
+    "\n",
+    "For the inversion scenario, we'd like to make the system do something a little more interesting than just relax to steady state.\n",
+    "To achieve that, we'll add a 1-year periodic oscillation to the accumulation rate.\n",
+    "The only change in the core simulation loop is that now we're interpolating a new value to the accumulation rate at every step.\n",
+    "Additionally, we're keeping the full time history of the system state in a list instead of just storing the final state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from numpy import pi as π\n",
+    "\n",
+    "final_time = 25.0\n",
+    "dt = 1.0 / 24\n",
+    "\n",
+    "hs = [h.copy(deepcopy=True)]\n",
+    "ss = [s.copy(deepcopy=True)]\n",
+    "us = [u.copy(deepcopy=True)]\n",
+    "\n",
+    "h_in = Constant(100.0)\n",
+    "a = firedrake.Function(Q2)\n",
+    "δa = Constant(0.2)\n",
+    "\n",
+    "num_steps = int(final_time / dt)\n",
+    "for step in tqdm.trange(num_steps):\n",
+    "    t = step * dt\n",
+    "    a.interpolate(a_0 + δa * firedrake.sin(2 * π * t))\n",
+    "    \n",
+    "    h = flow_solver.prognostic_solve(\n",
+    "        dt,\n",
+    "        thickness=h,\n",
+    "        velocity=u,\n",
+    "        accumulation=a,\n",
+    "        thickness_inflow=h_in,\n",
+    "    )\n",
+    "    s = icepack.compute_surface(thickness=h, bed=z_b)\n",
+    "\n",
+    "    u = flow_solver.diagnostic_solve(\n",
+    "        velocity=u,\n",
+    "        thickness=h,\n",
+    "        surface=s,\n",
+    "        fluidity=A,\n",
+    "        friction=C,\n",
+    "    )\n",
+    "\n",
+    "    hs.append(h.copy(deepcopy=True))\n",
+    "    ss.append(s.copy(deepcopy=True))\n",
+    "    us.append(u.copy(deepcopy=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plot below shows the average thickness of the glacier over time.\n",
+    "By the end of the interval the system has migrated towards a reasonably stable limit cycle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "average_thicknesses = np.array([firedrake.assemble(h * dx) / (Lx * Ly) for h in hs])\n",
+    "times = np.linspace(0, final_time, num_steps + 1)\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.set_xlabel(\"time (years)\")\n",
+    "ax.set_ylabel(\"average thickness (meters)\")\n",
+    "ax.plot(times, average_thicknesses);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Hindcasting\n",
+    "\n",
+    "We're now going to see if we can recover the state of the system at time $t = 23.5$ from knowledge of the system state at time $t = 25$.\n",
+    "The biggest departure in this notebook from the previous demonstration of statistical estimation problems is that now our simulation includes a full loop over all timesteps, rather than a single diagnostic solve.\n",
+    "The simulation has to take in the controls (the unknown initial thickness) and return the observables (the final thickness).\n",
+    "There are a few extra variables, like the start and end times and the mean and fluctuations of the accumulation rate, that come in implicitly but aren't actual function arguments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_time = 23.5\n",
+    "final_time = 25.0\n",
+    "\n",
+    "def simulation(h_initial):\n",
+    "    a = firedrake.Function(Q2)\n",
+    "    h = h_initial.copy(deepcopy=True)\n",
+    "    s = icepack.compute_surface(thickness=h, bed=z_b)\n",
+    "    u = flow_solver.diagnostic_solve(\n",
+    "        velocity=us[-1].copy(deepcopy=True), # Check for necessity of deepcopy\n",
+    "        thickness=h,\n",
+    "        surface=s,\n",
+    "        fluidity=A,\n",
+    "        friction=C,\n",
+    "    )\n",
+    "    t = Constant(start_time)\n",
+    "\n",
+    "    num_steps = int((final_time - start_time) / dt)\n",
+    "    for step in tqdm.trange(num_steps):\n",
+    "        t = Constant(t + dt)\n",
+    "        a.interpolate(a_0 + δa * firedrake.sin(2 * π * t))\n",
+    "\n",
+    "        h = flow_solver.prognostic_solve(\n",
+    "            dt,\n",
+    "            thickness=h,\n",
+    "            velocity=u,\n",
+    "            accumulation=a,\n",
+    "            thickness_inflow=h_in,\n",
+    "        )\n",
+    "        s = icepack.compute_surface(thickness=h, bed=z_b)\n",
+    "\n",
+    "        u = flow_solver.diagnostic_solve(\n",
+    "            velocity=u,\n",
+    "            thickness=h,\n",
+    "            surface=s,\n",
+    "            fluidity=A,\n",
+    "            friction=C,\n",
+    "        )\n",
+    "\n",
+    "    return h"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The loss functional calculates how well the final thickness and velocity from the simulation matches that from the actual time series."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def loss_functional(h_final):\n",
+    "    σ_h = Constant(1.0)\n",
+    "    return 0.5 / area * ((h_final - hs[-1]) / σ_h) ** 2 * dx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the previous demonstration of inverse methods, we used a prior that favored a smooth value of the fluidity:\n",
+    "\n",
+    "$$R(\\theta) = \\frac{\\alpha^2}{2}\\int_\\Omega|\\nabla\\theta|^2dx.$$\n",
+    "\n",
+    "Here we have a little more knowledge; while the initial state might depart somewhat from the final state, we expect the difference between the two to be fairly smooth.\n",
+    "So we'll instead use the prior\n",
+    "\n",
+    "$$R(h(t_0)) = \\frac{\\alpha^2}{2}\\int_\\Omega|\\nabla(h(t_1) - h(t_0))|^2dx.$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def regularization(h_initial):\n",
+    "    α = Constant(0.0)\n",
+    "    δh = h_initial - hs[-1]\n",
+    "    return 0.5 * α ** 2 / area * inner(grad(δh), grad(δh)) * dx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As our starting guess for the initial thickness, we'll assume that it's equal to the final thickness."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h_initial = hs[-1].copy(deepcopy=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We've added a few extra options to pass to the optimizer in order to guarantee convergence to the right solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from icepack.statistics import StatisticsProblem, MaximumProbabilityEstimator\n",
+    "\n",
+    "stats_problem = StatisticsProblem(\n",
+    "    simulation=simulation,\n",
+    "    loss_functional=loss_functional,\n",
+    "    regularization=regularization,\n",
+    "    controls=h_initial,\n",
+    ")\n",
+    "\n",
+    "estimator = MaximumProbabilityEstimator(\n",
+    "    stats_problem,\n",
+    "    algorithm=\"bfgs\",\n",
+    "    memory=10,\n",
+    "    gradient_tolerance=1e-12,\n",
+    "    step_tolerance=5e-14,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h_min = estimator.solve()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The minimizer is appreciably different from the thickness at $t = 25.0$ and very to the value at $t = 23.5$, so the algorithm has reproduced the initial condition that we pretended not to know."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"|h_min - h(25.0)|: {firedrake.norm(h_min - hs[-1])}\")\n",
+    "num_steps = int((final_time - start_time) / dt)\n",
+    "print(f\"|h_min - h(23.5)|: {firedrake.norm(h_min - hs[-1 - num_steps])}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import icepack.plot\n",
+    "\n",
+    "δh = interpolate(h_min - hs[-1 - num_steps], Q2)\n",
+    "fig, axes = icepack.plot.subplots()\n",
+    "axes.set_title(\"Estimated - True thickness\")\n",
+    "colors = firedrake.tripcolor(δh, vmin=-0.002, vmax=+0.002, cmap=\"RdBu\", axes=axes)\n",
+    "fig.colorbar(colors, fraction=0.01, pad=0.046);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Conclusion\n",
+    "\n",
+    "In previous demos, we've shown how use measurements of observable fields, like ice velocity and thickness, to estimate unknown parameters that satisfy constraints from a physics model.\n",
+    "The physics model was fairly rudimentary before -- taking in a single field like the ice fluidity and returning the ice velocity as computed from the momentum conservation equation.\n",
+    "Here we showed how to use much more complex simulations involving a full timestepping loop.\n",
+    "Instead of estimating an unobservable parameter of the system, like the fluidity or friction coefficient, we instead showed how to estimate the thickness at a different time from when it was observed.\n",
+    "\n",
+    "Solving these kinds of problems is more computationally expensive and finding better or faster algorithms is an active area of research.\n",
+    "While costly, the capability does open up many more possible research directions and improvements on existing practice.\n",
+    "For example, when estimating the ice fluidity or friction, it's common to assume that the thickness and velocity measurements were taken at the same time.\n",
+    "This assumption is almost never exactly true.\n",
+    "The ability to do time-dependent data assimilation means that we can dispense with it."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "firedrake",
+   "language": "python",
+   "name": "firedrake"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/tutorials/05-ice-shelf-inverse.ipynb
+++ b/notebooks/tutorials/05-ice-shelf-inverse.ipynb
@@ -63,35 +63,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import subprocess\n",
     "import geojson\n",
+    "import firedrake\n",
     "import icepack\n",
     "\n",
-    "outline_filename = icepack.datasets.fetch_outline('larsen')\n",
-    "with open(outline_filename, 'r') as outline_file:\n",
+    "outline_filename = icepack.datasets.fetch_outline(\"larsen\")\n",
+    "with open(outline_filename, \"r\") as outline_file:\n",
     "    outline = geojson.load(outline_file)\n",
-    "    \n",
+    "\n",
     "geometry = icepack.meshing.collection_to_geo(outline)\n",
-    "with open('larsen.geo', 'w') as geo_file:\n",
-    "    geo_file.write(geometry.get_code())"
+    "with open(\"larsen.geo\", \"w\") as geo_file:\n",
+    "    geo_file.write(geometry.get_code())\n",
+    "    \n",
+    "command = \"gmsh -2 -format msh2 -v 2 -o larsen.msh larsen.geo\"\n",
+    "subprocess.run(command.split())\n",
+    "mesh = firedrake.Mesh(\"larsen.msh\")"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "!gmsh -2 -format msh2 -v 2 -o larsen.msh larsen.geo"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import firedrake\n",
-    "mesh = firedrake.Mesh('larsen.msh')"
+    "The code below is the same boilerplate as in the previous tutorial for plotting simulation results on top of the mosaic of Antarctica image."
    ]
   },
   {
@@ -104,41 +98,47 @@
     "import rasterio\n",
     "import icepack.plot\n",
     "\n",
-    "features = [feature['geometry'] for feature in outline['features']]\n",
+    "features = [feature[\"geometry\"] for feature in outline[\"features\"]]\n",
     "xmin, ymin, xmax, ymax = np.inf, np.inf, -np.inf, -np.inf\n",
     "δ = 50e3\n",
-    "for feature in outline['features']:\n",
-    "    for line_string in feature['geometry']['coordinates']:\n",
+    "for feature in outline[\"features\"]:\n",
+    "    for line_string in feature[\"geometry\"][\"coordinates\"]:\n",
     "        xs = np.array(line_string)\n",
     "        x, y = xs[:, 0], xs[:, 1]\n",
     "        xmin, ymin = min(xmin, x.min() - δ), min(ymin, y.min() - δ)\n",
     "        xmax, ymax = max(xmax, x.max() + δ), max(ymax, y.max() + δ)\n",
-    "        \n",
+    "\n",
     "image_filename = icepack.datasets.fetch_mosaic_of_antarctica()\n",
-    "with rasterio.open(image_filename, 'r') as image_file:\n",
+    "with rasterio.open(image_filename, \"r\") as image_file:\n",
     "    height, width = image_file.height, image_file.width\n",
     "    transform = image_file.transform\n",
     "    window = rasterio.windows.from_bounds(\n",
-    "        left=xmin, bottom=ymin, right=xmax, top=ymax,\n",
-    "        width=width, height=height, transform=transform\n",
+    "        left=xmin,\n",
+    "        bottom=ymin,\n",
+    "        right=xmax,\n",
+    "        top=ymax,\n",
+    "        width=width,\n",
+    "        height=height,\n",
+    "        transform=transform,\n",
     "    )\n",
     "    image = image_file.read(indexes=1, window=window, masked=True)\n",
+    "\n",
     "\n",
     "def subplots(*args, **kwargs):\n",
     "    fig, axes = icepack.plot.subplots(*args, **kwargs)\n",
     "    xmin, ymin, xmax, ymax = rasterio.windows.bounds(window, transform)\n",
     "    kw = {\n",
-    "        'extent': (xmin, xmax, ymin, ymax),\n",
-    "        'cmap': 'Greys_r',\n",
-    "        'vmin': 12e3,\n",
-    "        'vmax':16.38e3\n",
+    "        \"extent\": (xmin, xmax, ymin, ymax),\n",
+    "        \"cmap\": \"Greys_r\",\n",
+    "        \"vmin\": 12e3,\n",
+    "        \"vmax\": 16.38e3,\n",
     "    }\n",
     "    try:\n",
     "        axes.imshow(image, **kw)\n",
     "    except AttributeError:\n",
     "        for ax in axes:\n",
     "            ax.imshow(image, **kw)\n",
-    "    \n",
+    "\n",
     "    return fig, axes"
    ]
   },
@@ -149,11 +149,8 @@
    "outputs": [],
    "source": [
     "fig, axes = subplots()\n",
-    "axes.set_xlabel('meters')\n",
-    "kwargs = {\n",
-    "    'interior_kw': {'linewidth': .25},\n",
-    "    'boundary_kw': {'linewidth': 2}\n",
-    "}\n",
+    "axes.set_xlabel(\"meters\")\n",
+    "kwargs = {\"interior_kw\": {\"linewidth\": 0.25}, \"boundary_kw\": {\"linewidth\": 2}}\n",
     "icepack.plot.triplot(mesh, axes=axes, **kwargs)\n",
     "axes.legend();"
    ]
@@ -171,17 +168,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from firedrake import inner, grad, dx\n",
+    "from firedrake import assemble, Constant, inner, grad, dx\n",
     "\n",
     "thickness_filename = icepack.datasets.fetch_bedmachine_antarctica()\n",
-    "thickness = rasterio.open(f'netcdf:{thickness_filename}:thickness', 'r')\n",
+    "thickness = rasterio.open(f\"netcdf:{thickness_filename}:thickness\", \"r\")\n",
     "\n",
-    "Q = firedrake.FunctionSpace(mesh, family='CG', degree=2)\n",
+    "Q = firedrake.FunctionSpace(mesh, family=\"CG\", degree=2)\n",
     "h0 = icepack.interpolate(thickness, Q)\n",
     "\n",
     "h = h0.copy(deepcopy=True)\n",
-    "α = firedrake.Constant(2e3)\n",
-    "J = 0.5 * ((h - h0)**2 + α**2 * inner(grad(h), grad(h))) * dx\n",
+    "α = Constant(2e3)\n",
+    "J = 0.5 * ((h - h0) ** 2 + α ** 2 * inner(grad(h), grad(h))) * dx\n",
     "F = firedrake.derivative(J, h)\n",
     "firedrake.solve(F == 0, h)"
    ]
@@ -201,12 +198,12 @@
    "outputs": [],
    "source": [
     "velocity_filename = icepack.datasets.fetch_measures_antarctica()\n",
-    "vx = rasterio.open(f'netcdf:{velocity_filename}:VX', 'r')\n",
-    "vy = rasterio.open(f'netcdf:{velocity_filename}:VY', 'r')\n",
-    "stdx = rasterio.open(f'netcdf:{velocity_filename}:ERRX', 'r')\n",
-    "stdy = rasterio.open(f'netcdf:{velocity_filename}:ERRY', 'r')\n",
+    "vx = rasterio.open(f\"netcdf:{velocity_filename}:VX\", \"r\")\n",
+    "vy = rasterio.open(f\"netcdf:{velocity_filename}:VY\", \"r\")\n",
+    "stdx = rasterio.open(f\"netcdf:{velocity_filename}:ERRX\", \"r\")\n",
+    "stdy = rasterio.open(f\"netcdf:{velocity_filename}:ERRY\", \"r\")\n",
     "\n",
-    "V = firedrake.VectorFunctionSpace(mesh, family='CG', degree=2)\n",
+    "V = firedrake.VectorFunctionSpace(mesh, family=\"CG\", degree=2)\n",
     "u_obs = icepack.interpolate((vx, vy), V)\n",
     "σx = icepack.interpolate(stdx, Q)\n",
     "σy = icepack.interpolate(stdy, Q)"
@@ -226,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "σ = firedrake.interpolate(firedrake.sqrt(σx**2 + σy**2), Q)\n",
+    "σ = firedrake.interpolate(firedrake.sqrt(σx ** 2 + σy ** 2), Q)\n",
     "fig, axes = subplots()\n",
     "colors = icepack.plot.tripcolor(σ, vmin=0, axes=axes)\n",
     "fig.colorbar(colors);"
@@ -246,29 +243,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "T = firedrake.Constant(260)\n",
+    "T = Constant(260)\n",
     "A0 = icepack.rate_factor(T)\n",
     "\n",
+    "\n",
     "def viscosity(**kwargs):\n",
-    "    u = kwargs['velocity']\n",
-    "    h = kwargs['thickness']\n",
-    "    θ = kwargs['log_fluidity']\n",
-    "    \n",
+    "    u = kwargs[\"velocity\"]\n",
+    "    h = kwargs[\"thickness\"]\n",
+    "    θ = kwargs[\"log_fluidity\"]\n",
+    "\n",
     "    A = A0 * firedrake.exp(θ)\n",
     "    return icepack.models.viscosity.viscosity_depth_averaged(\n",
     "        velocity=u, thickness=h, fluidity=A\n",
     "    )\n",
     "\n",
-    "θ = firedrake.Function(Q)\n",
     "\n",
     "model = icepack.models.IceShelf(viscosity=viscosity)\n",
-    "opts = {'dirichlet_ids': [2, 4, 5, 6, 7, 8, 9]}\n",
+    "opts = {\n",
+    "    \"dirichlet_ids\": [2, 4, 5, 6, 7, 8, 9],\n",
+    "    \"diagnostic_solver_type\": \"petsc\",\n",
+    "    \"diagnostic_solver_parameters\": {\n",
+    "        \"snes_type\": \"newtontr\",\n",
+    "        \"ksp_type\": \"gmres\",\n",
+    "        \"pc_type\": \"lu\",\n",
+    "        \"pc_factor_mat_solver_type\": \"mumps\",\n",
+    "    },\n",
+    "}\n",
     "solver = icepack.solvers.FlowSolver(model, **opts)\n",
     "\n",
+    "θ = firedrake.Function(Q)\n",
     "u = solver.diagnostic_solve(\n",
-    "    velocity=u_obs, \n",
+    "    velocity=u_obs,\n",
     "    thickness=h,\n",
-    "    log_fluidity=θ\n",
+    "    log_fluidity=θ,\n",
     ")"
    ]
   },
@@ -288,9 +295,9 @@
     "fig, axes = subplots(ncols=2, sharex=True, sharey=True)\n",
     "for ax in axes:\n",
     "    ax.get_xaxis().set_visible(False)\n",
-    "kwargs = {'precision': 1000, 'density': 2500, 'vmin': 0, 'vmax': 750}\n",
-    "axes[0].set_title('Computed')\n",
-    "axes[1].set_title('Observed')\n",
+    "kwargs = {\"precision\": 1000, \"density\": 2500, \"vmin\": 0, \"vmax\": 750}\n",
+    "axes[0].set_title(\"Computed\")\n",
+    "axes[1].set_title(\"Observed\")\n",
     "icepack.plot.streamplot(u, axes=axes[0], **kwargs)\n",
     "icepack.plot.streamplot(u_obs, axes=axes[1], **kwargs);"
    ]
@@ -320,8 +327,7 @@
     "* a smoothness metric\n",
     "\n",
     "We already have the physics model and some initial guesses.\n",
-    "The next step is to write a pair of Python functions that will create the model-data misfit functional and the regularization functional.\n",
-    "We'll pass these functions to the inverse problem when we create it."
+    "The physics are wrapped up in the Python function `simulation` defined below; we'll pass this function when we create the inverse problem."
    ]
   },
   {
@@ -330,30 +336,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import icepack.inverse\n",
-    "\n",
-    "def objective(u):\n",
-    "    δu = u - u_obs\n",
-    "    return 0.5 * ((δu[0] / σx)**2 + (δu[1] / σy)**2) * dx\n",
-    "\n",
-    "Θ = firedrake.Constant(1.)\n",
-    "L = firedrake.Constant(7.5e3)\n",
-    "def regularization(θ):\n",
-    "    return 0.5 * (L / Θ)**2 * inner(grad(θ), grad(θ)) * dx"
+    "def simulation(θ):\n",
+    "    return solver.diagnostic_solve(velocity=u_obs, thickness=h, log_fluidity=θ)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we create the `InverseProblem` object.\n",
-    "We've already mentioned several objects that the inverse problem needs -- the model, the initial guess, some functionals, etc.\n",
-    "Additionally, it needs to know the name of the observed field and the parameter (the `state_name` and `parameter_name`) arguments, since these values are passed to the forward solver as keyword arguments.\n",
-    "\n",
-    "The inverse solver will take this information and create a flow solver under the hood for us, but to do so it might need more information than we've already supplied.\n",
-    "First, the keyword argument `solver_kwargs` takes a dictionary of additional keyword arguments to pass when initializing the flow solver, such as Dirichlet IDs or tolerances.\n",
-    "Second, any additional arguments to the diagnostic solve procedure are passed in the dictionary `diagnostic_solve_kwargs`.\n",
-    "In our case, that consists of just the thickness field."
+    "Since the ice shelf is so large, we're going to want to scale some of our output quantities of interest by the area of the shelf.\n",
+    "This will make everything into nice dimensionless numbers, rather than on the order of $10{}^{10}$."
    ]
   },
   {
@@ -362,16 +354,61 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inverse_problem = icepack.inverse.InverseProblem(\n",
-    "    model=model,\n",
-    "    objective=objective,\n",
+    "area = assemble(Constant(1.0) * dx(mesh))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next step is to write a pair of Python functions that will create the model-data misfit functional and the regularization functional."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def loss_functional(u):\n",
+    "    δu = u - u_obs\n",
+    "    return 0.5 / Constant(area) * ((δu[0] / σx) ** 2 + (δu[1] / σy) ** 2) * dx\n",
+    "\n",
+    "\n",
+    "def regularization(θ):\n",
+    "    Θ = Constant(1.)\n",
+    "    L = Constant(7.5e3)\n",
+    "    return 0.5 / Constant(area) * (L / Θ)**2 * inner(grad(θ), grad(θ)) * dx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we'll create create a `StatisticsProblem` object.\n",
+    "To specify the problem, we need to give it:\n",
+    "\n",
+    "1. a procedure `simulation` for running the simulation, \n",
+    "2. a procedure `loss_functional` for evaluating how good our computed state fits the observations,\n",
+    "3. a procedure `regularization` for evaluating how simple or complex our guess for the parameters is, and finally\n",
+    "4. an initial guess for the unknown parameters.\n",
+    "\n",
+    "The statistics problem class uses the keyword argument \"controls\" here to reflect the generality of the types of fields that we might be solving for, which might not be \"parameters\" in the strictest sense of the word for some problems."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from icepack.statistics import StatisticsProblem, MaximumProbabilityEstimator\n",
+    "\n",
+    "problem = StatisticsProblem(\n",
+    "    simulation=simulation,\n",
+    "    loss_functional=loss_functional,\n",
     "    regularization=regularization,\n",
-    "    state_name='velocity',\n",
-    "    state=u,\n",
-    "    parameter_name='log_fluidity',\n",
-    "    parameter=θ,\n",
-    "    solver_kwargs=opts,\n",
-    "    diagnostic_solve_kwargs={'thickness': h}\n",
+    "    controls=θ,\n",
     ")"
    ]
   },
@@ -380,112 +417,9 @@
    "metadata": {},
    "source": [
     "Once we've created the problem, we then create a solver object that will iteratively search for a good value of the parameters.\n",
-    "The inverse solver has lots of moving parts, all of which are wrapped in a class that inherits from `icepack.inverse.InverseSolver`.\n",
-    "In our case, we'll be using the Gauss-Newton method, which is implemented in `GaussNewtonSolver`.\n",
-    "Using this class should save you from worrying about too many low-level details, but still provide a good amount of flexibility and transparency.\n",
-    "\n",
-    "As a convenience, the inverse solver can take in a function that it will call at the end of every iteration.\n",
-    "For this demonstration, we'll have it print out the values of the misfit and regularization functionals and the expected decrease in the sum of those two functionals.\n",
-    "The expected decrease in $J$ can be calculated as\n",
-    "\n",
-    "$$\\Delta = \\langle dJ, q\\rangle,$$\n",
-    "\n",
-    "where $dJ$ is the gradient of $J$ and $q$ is the search direction.\n",
-    "The expected decrease should be negative on every step -- after all, we're trying to find a minimizer of $J$.\n",
-    "If the expected decrease becomes positive, that suggests that we've found a local minimum and no more improvement is possible.\n",
-    "This is an important number to watch because it can tell you whether or not it's worthwhile to take more iterations of the solver.\n",
-    "\n",
-    "We've also passed some extra arguments to `assemble` to specify the quadrature rule for calculating the expected decrease.\n",
-    "The assembly routine will default to being very conservative and use a much more accurate quadrature rule than we really need and throw a warning about this behavior.\n",
-    "This step isn't strictly necessary, it's just good practice."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "qdegree = model.quadrature_degree(\n",
-    "    velocity=u, thickness=h, log_fluidity=θ\n",
-    ")\n",
-    "params = {'quadrature_degree': qdegree}\n",
-    "\n",
-    "area = firedrake.assemble(firedrake.Constant(1) * dx(mesh))\n",
-    "def callback(inverse_solver):\n",
-    "    dJ = inverse_solver.gradient\n",
-    "    q = inverse_solver.search_direction\n",
-    "    dJ_dq = firedrake.action(dJ, q)\n",
-    "    Δ = firedrake.assemble(dJ_dq, form_compiler_parameters=params)\n",
-    "\n",
-    "    E = firedrake.assemble(inverse_solver.objective)\n",
-    "    R = firedrake.assemble(inverse_solver.regularization)\n",
-    "    print(f'{E / area:g}, {R / area:g}, {Δ / area:g}')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You could also, say, make a plot of the state and parameter guess at every iteration to make a movie of how the algorithm progresses.\n",
-    "In programming parlance, a function like this is referred to as a *callback*.\n",
-    "\n",
-    "To create the solver object, we only need to give it a problem and optionally the callback function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "inverse_solver = icepack.inverse.GaussNewtonSolver(\n",
-    "    inverse_problem, callback, search_max_iterations=300\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As a general principle, it's a good idea to separate out the *specification* of a problem, in this case represented by the `InverseProblem` class, from the method used to solve the problem, represented by the `GaussNewtonSolver` class.\n",
-    "We've already seen this pattern before in how flow models (like `IceShelf`) are distinct from the objects that actually calculate the solutions (`FlowSolver`).\n",
-    "\n",
-    "Before setting the solver loose, let's look at the initial search direction.\n",
-    "The search direction is zero throughout most of the ice shelf.\n",
-    "It has strong positive anomalies in the vicinity of the sharp rifts on the grid-east side of the domain.\n",
-    "In other words, starting from a spatially constant initial guess, the fastest way to reduce the model-data misfit would be to make the shelf more fluid in the vicinity of these rifts."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, axes = subplots()\n",
-    "ϕ = inverse_solver.search_direction\n",
-    "colors = icepack.plot.tripcolor(\n",
-    "    ϕ, vmin=-8, vmax=+8, cmap='RdBu_r', axes=axes\n",
-    ")\n",
-    "fig.colorbar(colors);"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The search direction is obtained by multiplying the inverse of the Gauss-Newton matrix $H$ by the gradient $dJ$ of the objective function.\n",
-    "The Gauss-Newton matrix is dense, so we don't actually build the matrix directly.\n",
-    "Instead, the solver contains a procedure to multiply a vector by $H$, which is all that's necessary for using iterative methods to solve linear systems.\n",
-    "Computing the search direction like this is time-consuming, but results in far fewer iterations, so it's a net win.\n",
-    "\n",
-    "The solve method takes in a relative convergence tolerance, an absolute tolerance, and a maximum number of iterations, and it returns the total number of iterations necessary to achieve the given tolerances.\n",
-    "In our case, we'll stop once either (1) the relative decrease in the objective function from one iteration to the next is less than 1/200 or (2) the expected relative decrease in the objective is less than 1/1,000,000.\n",
-    "The relevant tolerances for these are respectively `rtol` and `etol`.\n",
-    "There's also an absolute stopping tolerance `atol`, which we won't use this time.\n",
-    "Absolute stopping tolerances are good for certain statistical problems where you know a priori how good of a fit to the data to expect.\n",
-    "\n",
+    "The inverse solver has lots of moving parts, all of which are wrapped up in the class `MaximumProbabilityEstimator`.\n",
+    "This class wraps up functionality for solving nonlinear optimization problems in a way that (hopefully) insulates you from having to know too much about the low-level details.\n",
+    "In this case, it'll call out to the [Rapid Optimization Library](https://trilinos.github.io/rol.html) (ROL).\n",
     "The algorithm takes about 30-45 minutes to run.\n",
     "Now would be the time to put on a fresh pot of coffee."
    ]
@@ -496,21 +430,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iterations = inverse_solver.solve(\n",
-    "    rtol=5e-3,\n",
-    "    etol=1e-6,\n",
-    "    atol=0.0,\n",
-    "    max_iterations=30\n",
-    ")"
+    "estimator = MaximumProbabilityEstimator(\n",
+    "    problem,\n",
+    "    gradient_tolerance=1e-4,\n",
+    "    step_tolerance=1e-1,\n",
+    "    max_iterations=50,\n",
+    ")\n",
+    "θ = estimator.solve()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The algorithm converges in just a few iterations because of how good a search direction we get from using the Gauss-Newton approximation.\n",
-    "It's also worth observing how quickly the magnitude of the expected decrease in the objective functional gets reduced on every iteration -- usually by at least a factor of four every time.\n",
-    "Other methods like gradient descent take many more iterations to reach the same agreement with the data."
+    "At each iteration, ROL will print out some information about the magnitude of the objective functional and its gradient so you can see how fast these quantities are decreasing.\n",
+    "Other methods might take more or less iterations to reach the same agreement with the data.\n",
+    "We've told the method to stop iterating once the norm of the gradient is less than $10^{-4}$, the norm of the step from one iteration to the next is less than $10^{-1}$, or if it takes more than 50 iterations.\n",
+    "In this case, it reached the gradient tolerance first.\n",
+    "It's a good idea to experiment with these tolerances to make sure that you've actually reached convergence."
    ]
   },
   {
@@ -520,11 +457,6 @@
     "### Analysis\n",
     "\n",
     "Now that we're done, we'll want to do some post-processing and analysis on the fluidity parameter that we inferred.\n",
-    "The inverse problem object stores the parameter we're inferring and the observed field as the properties `parameter` and `state` respectively.\n",
-    "The names are intentionally not specific to just ice shelves.\n",
-    "For other problems, we might instead be inferring a friction coefficient rather than a fluidity, or we might be observing the thickness instead of the velocity.\n",
-    "You can see all the publicly visible properties by typing `help(inverse_problem)`.\n",
-    "\n",
     "First, let's plot the parameter values."
    ]
   },
@@ -534,11 +466,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "θ = inverse_solver.parameter\n",
     "fig, axes = subplots()\n",
-    "colors = icepack.plot.tripcolor(\n",
-    "    θ, vmin=-5, vmax=+5, axes=axes\n",
-    ")\n",
+    "colors = icepack.plot.tripcolor(θ, vmin=-5, vmax=+5, axes=axes)\n",
     "fig.colorbar(colors);"
    ]
   },
@@ -568,12 +497,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "u = inverse_solver.state\n",
+    "u = simulation(θ)\n",
     "fig, axes = subplots()\n",
-    "δu = firedrake.interpolate((u - u_obs)**2/(2*σ**2), Q)\n",
-    "colors = icepack.plot.tripcolor(\n",
-    "    δu, vmin=0, vmax=50, cmap='Reds', axes=axes\n",
-    ")\n",
+    "δu = firedrake.interpolate((u - u_obs) ** 2 / (2 * σ ** 2), Q)\n",
+    "colors = icepack.plot.tripcolor(δu, vmin=0, vmax=50, cmap=\"Reds\", axes=axes)\n",
     "fig.colorbar(colors);"
    ]
   },
@@ -605,8 +532,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(icepack.norm(inverse_solver.parameter) / np.sqrt(area))\n",
-    "print(firedrake.assemble(inverse_solver.objective) / area)"
+    "print(icepack.norm(θ) / np.sqrt(area))\n",
+    "print(assemble(loss_functional(u) + regularization(θ)))"
    ]
   },
   {
@@ -642,7 +569,7 @@
     "4. We don't have a good way to also account for thickness errors, which are substantial.\n",
     "5. The ice shelf is actually grounded on some isolated pinning points or ice rises and we didn't add any basal drag.\n",
     "6. The model physics don't adequately account for the effects of rifts and crevasses.\n",
-    "7. I implemented the numerical optimization algorithm incorrectly.\n",
+    "7. The numerical optimization algorithm is implemented incorrectly.\n",
     "\n",
     "Failure modes 1 happens because we don't have the right prior distribution, while modes 2, 3, and 4 occur because we don't have the correct observational likelihood.\n",
     "Modes 5 and 6 are more insidious types of failure.\n",

--- a/test/statistics_test.py
+++ b/test/statistics_test.py
@@ -1,0 +1,166 @@
+# Copyright (C) 2022 by Daniel Shapero <shapero@uw.edu>
+#
+# This file is part of icepack.
+#
+# icepack is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# The full text of the license can be found in the file LICENSE in the
+# icepack source directory or at <http://www.gnu.org/licenses/>.
+
+import pytest
+import numpy as np
+import numpy.random as random
+import firedrake
+from firedrake import inner, grad, dx, exp, interpolate, as_vector
+import icepack
+from icepack.statistics import StatisticsProblem, MaximumProbabilityEstimator
+from icepack.constants import (
+    ice_density as ρ_I,
+    water_density as ρ_W,
+    gravity as g,
+    glen_flow_law as n,
+)
+
+
+def test_poisson_problem():
+    Nx, Ny = 32, 32
+
+    mesh = firedrake.UnitSquareMesh(Nx, Ny)
+    degree = 2
+    Q = firedrake.FunctionSpace(mesh, "CG", degree)
+    V = firedrake.FunctionSpace(mesh, "CG", degree)
+
+    x, y = firedrake.SpatialCoordinate(mesh)
+    f = interpolate(firedrake.Constant(1), Q)
+
+    def simulation(q):
+        # The momentum balance equations in icepack are formulated as a
+        # minimization problem, so for consistency we use the minimization
+        # form of the Poisson problem here.
+        u = firedrake.Function(V)
+        J = (0.5 * exp(q) * inner(grad(u), grad(u)) - f * u) * dx
+        F = firedrake.derivative(J, u)
+
+        bc = firedrake.DirichletBC(V, 0, "on_boundary")
+        problem = firedrake.NonlinearVariationalProblem(F, u, bc)
+        params = {
+            "solver_parameters": {
+                "pc_type": "lu",
+                "pc_factor_mat_solver_type": "mumps",
+            }
+        }
+        solver = firedrake.NonlinearVariationalSolver(problem, **params)
+        solver.solve()
+
+        return u
+
+    q_true = interpolate(-4 * ((x - 0.5) ** 2 + (y - 0.5) ** 2), Q)
+    u_obs = simulation(q_true)
+
+    def loss_functional(u):
+        return 0.5 * (u - u_obs) ** 2 * dx
+
+    α = firedrake.Constant(1e-4)
+
+    def regularization(q):
+        return 0.5 * α ** 2 * inner(grad(q), grad(q)) * dx
+
+    q_initial = firedrake.Function(Q)
+    problem = StatisticsProblem(simulation, loss_functional, regularization, q_initial)
+    estimator = MaximumProbabilityEstimator(problem, gradient_tolerance=1e-7)
+    q = estimator.solve()
+
+    assert firedrake.norm(q - q_true) < 0.25
+
+
+@pytest.mark.parametrize("with_noise", [False, True])
+def test_ice_shelf_inverse(with_noise):
+    Nx, Ny = 32, 32
+    Lx, Ly = 20e3, 20e3
+
+    u0 = 100
+    h0, δh = 500, 100
+    T0, δT = 254.15, 5.0
+    A0 = icepack.rate_factor(T0)
+    δA = icepack.rate_factor(T0 + δT) - A0
+
+    def exact_u(x):
+        ρ = ρ_I * (1 - ρ_I / ρ_W)
+        Z = icepack.rate_factor(T0) * (ρ * g * h0 / 4) ** n
+        q = 1 - (1 - (δh / h0) * (x / Lx)) ** (n + 1)
+        δu = Z * q * Lx * (h0 / δh) / (n + 1)
+        return u0 + δu
+
+    mesh = firedrake.RectangleMesh(Nx, Ny, Lx, Ly)
+    degree = 2
+    V = firedrake.VectorFunctionSpace(mesh, "CG", degree)
+    Q = firedrake.FunctionSpace(mesh, "CG", degree)
+
+    x, y = firedrake.SpatialCoordinate(mesh)
+    u_initial = interpolate(as_vector((exact_u(x), 0)), V)
+    q_initial = interpolate(firedrake.Constant(0), Q)
+    h = interpolate(h0 - δh * x / Lx, Q)
+
+    def viscosity(**kwargs):
+        u = kwargs["velocity"]
+        h = kwargs["thickness"]
+        q = kwargs["log_fluidity"]
+
+        A = A0 * firedrake.exp(-q / n)
+        return icepack.models.viscosity.viscosity_depth_averaged(
+            velocity=u, thickness=h, fluidity=A
+        )
+
+    model = icepack.models.IceShelf(viscosity=viscosity)
+    dirichlet_ids = [1, 3, 4]
+    flow_solver = icepack.solvers.FlowSolver(
+        model,
+        dirichlet_ids=dirichlet_ids,
+        diagnostic_solver_type="petsc",
+        diagnostic_solver_parameters={
+            "snes_type": "newtontr",
+            "ksp_type": "preonly",
+            "pc_type": "lu",
+            "pc_factor_mat_solver_type": "mumps",
+        },
+    )
+
+    r = firedrake.sqrt((x / Lx - 1 / 2) ** 2 + (y / Ly - 1 / 2) ** 2)
+    R = 1 / 4
+    expr = firedrake.max_value(0, δA * (1 - (r / R) ** 2))
+    q_true = firedrake.interpolate(-n * firedrake.ln(1 + expr / A0), Q)
+    u_true = flow_solver.diagnostic_solve(
+        velocity=u_initial, thickness=h, log_fluidity=q_true
+    )
+
+    u_obs = u_true.copy(deepcopy=True)
+    area = firedrake.assemble(firedrake.Constant(1) * dx(mesh))
+    σ = firedrake.Constant(1.0)
+    L = firedrake.Constant(1e-4 * Lx)
+    if with_noise:
+        σ = firedrake.Constant(0.001 * firedrake.norm(u_true) / np.sqrt(area))
+        shape = u_obs.dat.data_ro.shape
+        u_obs.dat.data[:] += float(σ) * random.standard_normal(shape) / np.sqrt(2)
+        L = firedrake.Constant(0.25 * Lx)
+
+    def loss_functional(u):
+        return 0.5 * ((u - u_obs) / σ) ** 2 * dx
+
+    def regularization(q):
+        return 0.5 * L ** 2 * inner(grad(q), grad(q)) * dx
+
+    def simulation(q):
+        return flow_solver.diagnostic_solve(
+            velocity=u_initial, thickness=h, log_fluidity=q
+        )
+
+    stats_problem = StatisticsProblem(
+        simulation, loss_functional, regularization, q_initial
+    )
+    estimator = MaximumProbabilityEstimator(stats_problem)
+    q = estimator.solve()
+
+    assert firedrake.norm(q - q_true) / firedrake.norm(q_initial - q_true) < 0.25


### PR DESCRIPTION
This PR adds a new module statistics.py which defines the classes StatisticsProblem and MaximumProbabilityEstimator. These are analogous to the InverseProblem/InverseSolver classes but for the fact that they use pyadjoint instead of the hand-coded adjoint calculation from before. This makes it possible to use the Firedrake VertexOnlyMesh features to do sparse data assimilation and to do time-dependent data assimilation. We now have a hard dependency on ROL to do the optimization. There are also two new tutorials on sparse and time-dependent data assimilation respectively.

The limitations are:
* have to use the PETSc diagnostic solver instead of the hand-written one in icepack, the latter of which is more robust on some inputs
* have to use ROL to do the optimization, for which our only algorithmic choices are full Newton with either line search or trust region, or BFGS with line search -- no Gauss-Newton operator