### PR TITLE
Interpolate 2D rasters to 3D meshes

### DIFF
--- a/icepack/interpolate.py
+++ b/icepack/interpolate.py
@@ -22,11 +22,12 @@ from scipy.interpolate import RegularGridInterpolator
 
 def _sample(dataset, X, method):
     xres = dataset.res[0]
+    yres = dataset.res[1]
     bounds = dataset.bounds
-    xmin = max(X[:, 0].min() - 2 * xres, bounds.left)
-    xmax = min(X[:, 0].max() + 2 * xres, bounds.right)
-    ymin = max(X[:, 1].min() - 2 * xres, bounds.bottom)
-    ymax = min(X[:, 1].max() + 2 * xres, bounds.top)
+    xmin = max(X[:, 0].min() - 3 * xres, bounds.left)
+    xmax = min(X[:, 0].max() + 3 * xres, bounds.right)
+    ymin = max(X[:, 1].min() - 3 * yres, bounds.bottom)
+    ymax = min(X[:, 1].max() + 3 * yres, bounds.top)
 
     window = rasterio.windows.from_bounds(
         left=xmin,

--- a/icepack/interpolate.py
+++ b/icepack/interpolate.py
@@ -70,11 +70,14 @@ def interpolate(f, Q, method="linear"):
 
     mesh = Q.mesh()
     element = Q.ufl_element()
-    if len(element.sub_elements()) > 0:
+
+    # Cannot take sub-elements if function is 3D scalar, otherwise shape will mismatch vertical basis
+    # This attempts to distinguish if multiple subelements due to dimension or vector function
+    if issubclass(type(element), firedrake.VectorElement):
         element = element.sub_elements()[0]
 
     V = firedrake.VectorFunctionSpace(mesh, element)
-    X = firedrake.interpolate(mesh.coordinates, V).dat.data_ro
+    X = firedrake.interpolate(mesh.coordinates, V).dat.data_ro[:, :2]
 
     q = firedrake.Function(Q)
 

--- a/test/grid_data_test.py
+++ b/test/grid_data_test.py
@@ -76,6 +76,25 @@ def test_interpolating_scalar_field():
     assert firedrake.norm(p - q) / firedrake.norm(p) < 1e-10
 
 
+def test_interpolating_scalar_field_3d():
+    n = 32
+    array = np.array([[(i + j) / n for j in range(n + 1)] for i in range(n + 1)])
+    missing = -9999.0
+    array[0, 0] = missing
+    array = np.flipud(array)
+    dataset = make_rio_dataset(array, missing)
+
+    mesh2d = make_domain(48, 48, xmin=1 / 4, ymin=1 / 4, width=1 / 2, height=1 / 2)
+    mesh = firedrake.ExtrudedMesh(mesh2d, layers=1)
+
+    x, y, z = firedrake.SpatialCoordinate(mesh)
+    Q = firedrake.FunctionSpace(mesh, "CG", 1, vfamily='R', vdegree=0)
+    p = firedrake.interpolate(x + y, Q)
+    q = icepack.interpolate(dataset, Q)
+
+    assert firedrake.norm(p - q) / firedrake.norm(p) < 1e-10
+
+
 def test_nearest_neighbor_interpolation():
     n = 32
     array = np.array([[(i + j) / n for j in range(n + 1)] for i in range(n + 1)])
@@ -111,6 +130,31 @@ def test_interpolating_vector_field():
     mesh = make_domain(48, 48, xmin=1 / 4, ymin=1 / 4, width=1 / 2, height=1 / 2)
     x, y = firedrake.SpatialCoordinate(mesh)
     V = firedrake.VectorFunctionSpace(mesh, "CG", 1)
+    u = firedrake.interpolate(firedrake.as_vector((x + y, x - y)), V)
+    v = icepack.interpolate((vx, vy), V)
+
+    assert firedrake.norm(u - v) / firedrake.norm(u) < 1e-10
+
+
+def test_interpolating_vector_field_3d():
+    n = 32
+    array_vx = np.array([[(i + j) / n for j in range(n + 1)] for i in range(n + 1)])
+    missing = -9999.0
+    array_vx[0, 0] = missing
+    array_vx = np.flipud(array_vx)
+
+    array_vy = np.array([[(j - i) / n for j in range(n + 1)] for i in range(n + 1)])
+    array_vy[-1, -1] = -9999.0
+    array_vy = np.flipud(array_vy)
+
+    vx = make_rio_dataset(array_vx, missing)
+    vy = make_rio_dataset(array_vy, missing)
+
+    mesh2d = make_domain(48, 48, xmin=1 / 4, ymin=1 / 4, width=1 / 2, height=1 / 2)
+    mesh = firedrake.ExtrudedMesh(mesh2d, layers=1)
+
+    x, y, z = firedrake.SpatialCoordinate(mesh)
+    V = firedrake.VectorFunctionSpace(mesh, "CG", 1, dim=2, vfamily='GL', vdegree=2)
     u = firedrake.interpolate(firedrake.as_vector((x + y, x - y)), V)
     v = icepack.interpolate((vx, vy), V)
 

--- a/test/grid_data_test.py
+++ b/test/grid_data_test.py
@@ -88,7 +88,7 @@ def test_interpolating_scalar_field_3d():
     mesh = firedrake.ExtrudedMesh(mesh2d, layers=1)
 
     x, y, z = firedrake.SpatialCoordinate(mesh)
-    Q = firedrake.FunctionSpace(mesh, "CG", 1, vfamily='R', vdegree=0)
+    Q = firedrake.FunctionSpace(mesh, "CG", 1, vfamily="R", vdegree=0)
     p = firedrake.interpolate(x + y, Q)
     q = icepack.interpolate(dataset, Q)
 
@@ -154,7 +154,7 @@ def test_interpolating_vector_field_3d():
     mesh = firedrake.ExtrudedMesh(mesh2d, layers=1)
 
     x, y, z = firedrake.SpatialCoordinate(mesh)
-    V = firedrake.VectorFunctionSpace(mesh, "CG", 1, dim=2, vfamily='GL', vdegree=2)
+    V = firedrake.VectorFunctionSpace(mesh, "CG", 1, dim=2, vfamily="GL", vdegree=2)
     u = firedrake.interpolate(firedrake.as_vector((x + y, x - y)), V)
     v = icepack.interpolate((vx, vy), V)
 


### PR DESCRIPTION
I think this is a safe fix for #95. This should allow, for example, the bed, surface, or 2D velocity field to be interpolated onto a function space for a 3D mesh (and works at least with `vfamily="R"`, `vfamily="GL"`, and `vfamily="CG"` with varying `vdegree`).