### PR TITLE
bug fix in Triangle mesh translation

### DIFF
--- a/icepack/meshing.py
+++ b/icepack/meshing.py
@@ -366,4 +366,4 @@ def triangle_to_firedrake(mesh, comm=firedrake.COMM_WORLD):
         marker = markers[vertices]
         plex.setLabelValue(dmcommon.FACE_SETS_LABEL, face, marker)
 
-    return firedrake.Mesh(plex)
+    return firedrake.Mesh(plex, reorder=False)

--- a/notebooks/how-to/03-adaptivity.ipynb
+++ b/notebooks/how-to/03-adaptivity.ipynb
@@ -847,7 +847,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We need to add `reorder=False` when creating the DMPlex in order to guarantee that the cells of the Firedrake and Triangle meshes are numbered the same way. The numbering has to be the same if we want to use some expression on the Firedrake side to determine how to refine the Triangle mesh.