### PR TITLE
Sidewall drag for flowlines

### DIFF
--- a/icepack/models/friction.py
+++ b/icepack/models/friction.py
@@ -64,6 +64,27 @@ def side_friction(**kwargs):
     return -m / (m + 1) * h * inner(τ, u_t)
 
 
+def side_friction_xz(**kwargs):
+    r"""Return the side wall friction part of the action functional
+
+    The component of the action functional due to friction along the side
+    walls of the domain is
+
+    .. math::
+       E(u) = -\frac{m}{m + 1}\int_\Gamma h\tau(u, C_s)\cdot u\; ds
+
+    where :math:`\tau(u, C_s)` is the side wall shear stress, :math:`ds`
+    is the element of surface area and :math:`\Gamma` are the side walls.
+    Side wall friction is relevant for glaciers that flow through a fjord
+    with rock walls on either side.
+    """
+    u, h = itemgetter("velocity", "thickness")(kwargs)
+    Cs = kwargs.get("side_friction", firedrake.Constant(0.0))
+
+    τ = friction_stress(u, Cs)
+    return -m / (m + 1) * h * inner(τ, u)
+
+
 def normal_flow_penalty(**kwargs):
     r"""Return the penalty for flow normal to the domain boundary
 

--- a/icepack/models/hybrid.py
+++ b/icepack/models/hybrid.py
@@ -15,7 +15,7 @@ from operator import itemgetter
 import sympy
 import firedrake
 from firedrake import inner, outer, sqrt, dx, ds_b, ds_v
-from icepack.models.friction import bed_friction, side_friction, normal_flow_penalty
+from icepack.models.friction import bed_friction, side_friction, side_friction_xz, normal_flow_penalty
 from icepack.models.mass_transport import Continuity
 from icepack.constants import (
     ice_density as ρ_I,
@@ -200,6 +200,7 @@ class HybridModel:
         self.viscosity = add_kwarg_wrapper(viscosity)
         self.friction = add_kwarg_wrapper(friction)
         self.side_friction = add_kwarg_wrapper(side_friction)
+        self.side_friction_xz = add_kwarg_wrapper(side_friction_xz)
         self.gravity = add_kwarg_wrapper(gravity)
         self.terminus = add_kwarg_wrapper(terminus)
         self.penalty = add_kwarg_wrapper(normal_flow_penalty)
@@ -222,11 +223,12 @@ class HybridModel:
         gravity = self.gravity(**kwargs) * dx
         friction = self.friction(**kwargs) * ds_b
 
-        side_friction = self.side_friction(**kwargs) * ds_v(side_wall_ids)
         if get_mesh_axes(mesh) == "xyz":
             penalty = self.penalty(**kwargs) * ds_v(side_wall_ids)
+            side_friction = self.side_friction(**kwargs) * ds_v(side_wall_ids)
         else:
             penalty = 0.0
+            side_friction = self.side_friction_xz(**kwargs) * dx
 
         xdegree_u, zdegree_u = u.ufl_element().degree()
         degree_h = h.ufl_element().degree()[0]

--- a/icepack/models/hybrid.py
+++ b/icepack/models/hybrid.py
@@ -15,7 +15,12 @@ from operator import itemgetter
 import sympy
 import firedrake
 from firedrake import inner, outer, sqrt, dx, ds_b, ds_v
-from icepack.models.friction import bed_friction, side_friction, side_friction_xz, normal_flow_penalty
+from icepack.models.friction import (
+    bed_friction,
+    side_friction,
+    side_friction_xz,
+    normal_flow_penalty,
+)
 from icepack.models.mass_transport import Continuity
 from icepack.constants import (
     ice_density as ρ_I,


### PR DESCRIPTION
As best I can tell, it was not possible to use sidewall drag on a flowline since there is no sidewall id when the whole domain is a sidewall. I think this a pretty common use case for sidewall drag, since you get pretty fast velocities near termini otherwise. It has a good history of use (e.g., Gagliardini et al., 2010).

I simply changed things to make the whole domain a sidewall by default for XZ in the hybrid model, with drag coefficient equal to zero. In this case there is no normal vector to the wall, so I had to create a new type of friction as well (inelegant, but works). I didn't touch the SSA, though, so maybe that should be done before merging?

Also I think it is worth a test to be sure that this does not affect velocities as long as side_friction=0.0, but I am not sure how best to write such a test. Thought I would open the PR, though, and we can go from there.