### PR TITLE
Update ROL shims for new pyadjoint API

### DIFF
--- a/icepack/meshing.py
+++ b/icepack/meshing.py
@@ -351,7 +351,12 @@ def collection_to_triangle(collection, max_volume=None):
 def triangle_to_firedrake(mesh, comm=firedrake.COMM_WORLD):
     r"""Convert a generated Triangle geometry into a Firedrake mesh"""
     elements, points = mesh.elements, mesh.points
-    plex = firedrake.mesh._from_cell_list(2, elements, points, comm)
+    # TODO: Remove this when we fully switch to the new Firedrake meshing
+    # interface, `_from_cell_list` is deprecated
+    if hasattr(firedrake.mesh, "plex_from_cell_list"):
+        plex = firedrake.mesh.plex_from_cell_list(2, elements, points, comm)
+    else:
+        plex = firedrake.mesh._from_cell_list(2, elements, points, comm)
 
     markers = {
         tuple(sorted((v1, v2))): mesh.facet_markers[index]

--- a/icepack/statistics.py
+++ b/icepack/statistics.py
@@ -74,9 +74,14 @@ try:
 
         def update(self, x, flag, iteration):
             try:
-                self.val = self.rf(x.dat)
+                super().update(x, flag, iteration)
             except firedrake.ConvergenceError:
-                self.val = np.inf
+                # TODO: Remove this when we fully switch to the new pyadjoint
+                # interface, the `.val` member has changed to `._val`
+                if hasattr(self, "_val"):
+                    self._val = np.inf
+                else:
+                    self.val = np.inf
 
     class _ROLSolverWrapper(pyadjoint.ROLSolver):
         def __init__(self, problem, controls, inner_product="L2"):


### PR DESCRIPTION
The `val` member of ROLObjective was made private. Resolves dolfin-adjoint/pyadjoint#89.