### PR TITLE
Pin scipy version <= 1.9.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-scipy
+scipy<=1.9.3
 matplotlib
 rasterio>=1.2.7
 netCDF4

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_data={"icepack": ["registry-nsidc.txt", "registry-outlines.txt"]},
     install_requires=[
         "numpy",
-        "scipy",
+        "scipy<=1.9.3",
         "matplotlib",
         "rasterio>=1.2.7",
         "netCDF4",


### PR DESCRIPTION
Version 1.10.0 has introduced a bug in the interpolation routines we use whenever the input data are 32-bit floats.