### PR TITLE
Use our own fork of Trilinos and pyrol

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ MeshPy
 tqdm
 ipykernel[doc]
 nbconvert[doc]
-roltrilinos[opt]==0.0.9
-ROL[opt]==0.0.16
+roltrilinos @ git+https://github.com/icepack/Trilinos@190384db6cb1d148cea36f2d8d69033a90b2d991
+ROL @ git+https://github.com/icepack/pyrol@3bc1802e436eda8949a286abf54528c7a882f706

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setup(
     ],
     extras_require={
         "doc": ["sphinx", "ipykernel", "nbconvert", "nikola"],
-        "opt": ["roltrilinos==0.0.9", "ROL==0.0.16"],
+        "opt": [
+            "roltrilinos @ git+https://github.com/icepack/Trilinos.git",
+            "ROL @ git+https://github.com/icepack/pyrol.git",
+        ],
     },
 )


### PR DESCRIPTION
Installing Trilinos and ROL from pypi fails with recent C++ compilers and Python versions. This patch updates the icepack dependencies to use patched versions of these libraries.