### PR TITLE
Temporary workaround for pygmsh-6.x + numpy-2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        version: [2023-11, 2024-04]
+        version: [2023-11, 2024-04, 2024-07]
     runs-on: ubuntu-latest
     container:
       image: docker.io/firedrakeproject/firedrake-vanilla:${{ matrix.version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pooch",
     "gmsh",
     "pygmsh<=6.1.1",
-    "meshio>=3.3.1",
+    "meshio@git+https://github.com/icepack/meshio.git@v4.4.7",
     "MeshPy",
     "tqdm",
     "roltrilinos@git+https://github.com/icepack/Trilinos",


### PR DESCRIPTION
We remain pinned to meshio-4.4.6, which uses the `numpy.string_` class. This type has been removed from numpy-2.0 in favor of `numpy.bytes_`. This patch switches to using a fork I made of meshio that fixes the bug on numpy-2.0.