### PR TITLE
Update to using gmsh python API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           pip install git+https://github.com/icepack/pyrol.git@3bc1802e436eda8949a286abf54528c7a882f706
           pip install jupyter ipykernel nbconvert
           python -m ipykernel install --user --name=firedrake
-          pip install --editable .
+          pip install --editable ".[pygmsh]"
       - name: Run unit tests
         run: pytest
       - name: Run example notebooks

--- a/notebooks/how-to/03-adaptivity.ipynb
+++ b/notebooks/how-to/03-adaptivity.ipynb
@@ -100,7 +100,7 @@
     "    \n",
     "fig, axes = subplots()\n",
     "firedrake.triplot(coarse_mesh, axes=axes)\n",
-    "axes.legend();"
+    "axes.legend(loc=\"upper right\");"
    ]
   },
   {
@@ -830,7 +830,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/how-to/04-sparse-data.ipynb
+++ b/notebooks/how-to/04-sparse-data.ipynb
@@ -51,7 +51,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import subprocess\n",
     "import geojson\n",
     "import firedrake\n",
     "import icepack\n",
@@ -60,12 +59,7 @@
     "with open(outline_filename, \"r\") as outline_file:\n",
     "    outline = geojson.load(outline_file)\n",
     "\n",
-    "geometry = icepack.meshing.collection_to_geo(outline)\n",
-    "with open(\"larsen.geo\", \"w\") as geo_file:\n",
-    "    geo_file.write(geometry.get_code())\n",
-    "    \n",
-    "command = \"gmsh -2 -format msh2 -v 2 -o larsen.msh larsen.geo\"\n",
-    "subprocess.run(command.split())\n",
+    "icepack.meshing.collection_to_gmsh(outline).write(\"larsen.msh\")\n",
     "mesh = firedrake.Mesh(\"larsen.msh\")"
    ]
   },
@@ -136,7 +130,7 @@
     "    \"boundary_kw\": {\"linewidth\": 2},\n",
     "}\n",
     "firedrake.triplot(mesh, axes=axes, **kwargs)\n",
-    "axes.legend();"
+    "axes.legend(loc=\"upper right\");"
    ]
   },
   {
@@ -650,7 +644,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/00-meshes-functions.ipynb
+++ b/notebooks/tutorials/00-meshes-functions.ipynb
@@ -56,8 +56,9 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "fig, axes = plt.subplots()\n",
+    "axes.set_aspect(\"equal\")\n",
     "firedrake.triplot(mesh, axes=axes)\n",
-    "axes.legend();"
+    "axes.legend(loc=\"upper right\");"
    ]
   },
   {
@@ -508,7 +509,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/02-synthetic-ice-shelf.ipynb
+++ b/notebooks/tutorials/02-synthetic-ice-shelf.ipynb
@@ -40,7 +40,7 @@
     "In the first two demos, we used one of firedrake's built-in functions to create the geometry.\n",
     "For more complicated shapes you'll need to use a mesh generator, a program that turns a description of the boundary of a spatial domain into a triangulation of the interior.\n",
     "Two of the more popular 2D mesh generators are [gmsh](http://gmsh.info/) and [Triangle](https://www.cs.cmu.edu/~quake/triangle.html).\n",
-    "In this case we'll use gmsh because we can create the input file entirely in Python through the package [pygmsh](https://github.com/nschloe/pygmsh).\n",
+    "In this case we'll use gmsh because we can create the input file entirely in Python.\n",
     "\n",
     "We'll first define the mesh radius and the spacing for the mesh cells."
    ]
@@ -51,7 +51,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pygmsh\n",
+    "import gmsh\n",
+    "gmsh.initialize()\n",
     "\n",
     "R = 200e3\n",
     "δx = 5e3"
@@ -73,13 +74,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "geometry = pygmsh.built_in.Geometry()\n",
+    "geometry = gmsh.model.geo\n",
     "\n",
-    "x1 = geometry.add_point([-R, 0, 0], lcar=δx)\n",
-    "x2 = geometry.add_point([+R, 0, 0], lcar=δx)\n",
+    "x1 = geometry.add_point(-R, 0, 0, δx)\n",
+    "x2 = geometry.add_point(+R, 0, 0, δx)\n",
     "\n",
-    "center1 = geometry.add_point([0, 0, 0,], lcar=δx)\n",
-    "center2 = geometry.add_point([0, -4 * R, 0], lcar=δx)\n",
+    "center1 = geometry.add_point(0, 0, 0, δx)\n",
+    "center2 = geometry.add_point(0, -4 * R, 0, δx)\n",
     "\n",
     "arcs = [\n",
     "    geometry.add_circle_arc(x1, center1, x2),\n",
@@ -92,7 +93,7 @@
    "metadata": {},
    "source": [
     "Now that we've added the geometric elements of our domain, we also need to tell gmsh about the topology, i.e. how all the arcs are connected to each other and how they're oriented.\n",
-    "The physical lines and surfaces are added so that gmsh will tag each geometric entity with a number that we can use to set different boundary conditions."
+    "The physical groups are added so that gmsh will tag each geometric entity with a number that we can use to set different boundary conditions."
    ]
   },
   {
@@ -101,20 +102,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "line_loop = geometry.add_line_loop(arcs)\n",
-    "plane_surface = geometry.add_plane_surface(line_loop)\n",
+    "line_loop = geometry.add_curve_loop(arcs)\n",
+    "plane_surface = geometry.add_plane_surface([line_loop])\n",
     "\n",
-    "physical_lines = [geometry.add_physical(arc) for arc in arcs]\n",
-    "physical_surface = geometry.add_physical(plane_surface)"
+    "physical_lines = [geometry.add_physical_group(1, [arc]) for arc in arcs]\n",
+    "physical_surface = geometry.add_physical_group(2, [plane_surface])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This completes the definition of the input geometry.\n",
-    "The method `get_code` of the geometry object returns the string describing it in the syntax that gmsh expects.\n",
-    "We'll write this string out to a file with the extension `.geo`."
+    "To get a mesh, we need to (1) synchronize the geometry model in order to add all its elements into an internal data structure for gmsh, (2) generate the triangular mesh, and (3) write it out to a file.\n",
+    "We can also finalize gmsh in order to save some memory, although that isn't mandatory."
    ]
   },
   {
@@ -123,44 +123,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(\"ice-shelf.geo\", \"w\") as geo_file:\n",
-    "    geo_file.write(geometry.get_code())"
+    "geometry.synchronize()\n",
+    "gmsh.model.mesh.generate(2)\n",
+    "gmsh.write(\"ice-shelf.msh\")\n",
+    "gmsh.finalize()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we'll call gmsh from the command line on the input file we just created.\n",
-    "The mesh generator will read the description of the domain boundary, triangulate the interior of the domain, and output a file with the extension `.msh`.\n",
-    "Other mesh generators have different input and output formats, but the procedure is roughly the same.\n",
-    "\n",
-    "In a jupyter notebook, you can use an exclamation mark followed by a command to execute this command at the shell rather than in Python.\n",
-    "We'll call `gmsh` from the command line with the following arguments:\n",
-    "\n",
-    "* `-2`: generate a 2D mesh as opposed to 3D\n",
-    "* `-format msh2`: specify the storage format of the output file\n",
-    "* `-o ice-shelf.msh`: name of the output file\n",
-    "* `ice-shelf.geo`: the input data\n",
-    "\n",
-    "The shell command (without the exclamation mark) is what you would use if you were working directly from the command line rather than in a notebook."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!gmsh -2 -format msh2 -o ice-shelf.msh ice-shelf.geo"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The terminal output from gmsh gives us some diagnostics like how many vertices and triangles it contains.\n",
-    "This is also where gmsh will report if something went wrong -- a syntax error in the .geo file, a degenerate input geometry, and so forth."
+    "The terminal output from gmsh gives us some diagnostics, like how many vertices and triangles the mesh contains.\n",
+    "This is where gmsh will report if something went wrong like a degenerate input geometry.\n",
+    "If these steps feel confusing, don't worry -- we will only rarely need to create meshes by hand this way.\n",
+    "It's more common to start with a digitized glacier outline in the form of a shapefile or a GeoJSON file.\n",
+    "Icepack includes routines in the `meshing` module to automatically generate a mesh from vector data.\n",
+    "We'll see how to use those routines in the subsequent tutorials."
    ]
   },
   {
@@ -202,7 +180,7 @@
     "\n",
     "fig, axes = icepack.plot.subplots()\n",
     "firedrake.triplot(mesh, axes=axes)\n",
-    "axes.legend();"
+    "axes.legend(loc=\"lower left\");"
    ]
   },
   {
@@ -935,7 +913,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/03-larsen-ice-shelf.ipynb
+++ b/notebooks/tutorials/03-larsen-ice-shelf.ipynb
@@ -300,9 +300,10 @@
    "source": [
     "### Meshing\n",
     "\n",
-    "Next we'll take this GeoJSON object and translate it into a geometry object from pygmsh.\n",
-    "The function to do that is contained in the module `icepack.meshing`.\n",
-    "We can then save this to a .geo file and run gmsh on the result, just like we did in the previous demo."
+    "In the synthetic ice shelf tutorial, we generated a mesh by calling the gmsh interface directly.\n",
+    "The geometry in that tutorial was simple, but here we have a digitized outline that includes several holes.\n",
+    "The module `icepack.meshing` includes routines for automating the conversion of vector data into triangular meshes.\n",
+    "Here we'll generate a mesh using gmsh and write it out to disk."
    ]
   },
   {
@@ -311,39 +312,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "geometry = icepack.meshing.collection_to_geo(outline)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "with open(\"larsen.geo\", \"w\") as geo_file:\n",
-    "    geo_file.write(geometry.get_code())"
+    "gmsh_mesh = icepack.meshing.collection_to_gmsh(outline)\n",
+    "gmsh_mesh.write(\"larsen.msh\", verbose=False)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The call to gmsh is the same as in the previous demo, but we'll make the output less verbose by passing the flag `-v 2` as well."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!gmsh -2 -format msh2 -v 2 -o larsen.msh larsen.geo"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "We could also have chained the two commands together into one.\n",
     "Now that we've generated the mesh we can read it just like we did in the previous demo."
    ]
   },
@@ -381,7 +358,7 @@
     "    \"boundary_kw\": {\"linewidth\": 2},\n",
     "}\n",
     "firedrake.triplot(mesh, axes=axes, **kwargs)\n",
-    "axes.legend();"
+    "axes.legend(loc=\"upper right\");"
    ]
   },
   {
@@ -874,7 +851,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/05-ice-shelf-inverse.ipynb
+++ b/notebooks/tutorials/05-ice-shelf-inverse.ipynb
@@ -63,7 +63,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import subprocess\n",
     "import geojson\n",
     "import firedrake\n",
     "import icepack\n",
@@ -72,12 +71,7 @@
     "with open(outline_filename, \"r\") as outline_file:\n",
     "    outline = geojson.load(outline_file)\n",
     "\n",
-    "geometry = icepack.meshing.collection_to_geo(outline)\n",
-    "with open(\"larsen.geo\", \"w\") as geo_file:\n",
-    "    geo_file.write(geometry.get_code())\n",
-    "    \n",
-    "command = \"gmsh -2 -format msh2 -v 2 -o larsen.msh larsen.geo\"\n",
-    "subprocess.run(command.split())\n",
+    "icepack.meshing.collection_to_gmsh(outline).write(\"larsen.msh\")\n",
     "mesh = firedrake.Mesh(\"larsen.msh\")"
    ]
   },
@@ -147,7 +141,7 @@
     "    \"boundary_kw\": {\"linewidth\": 2},\n",
     "}\n",
     "firedrake.triplot(mesh, axes=axes, **kwargs)\n",
-    "axes.legend();"
+    "axes.legend(loc=\"upper right\");"
    ]
   },
   {
@@ -606,7 +600,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/07-rgi-meshing.ipynb
+++ b/notebooks/tutorials/07-rgi-meshing.ipynb
@@ -179,28 +179,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "geometry = icepack.meshing.collection_to_geo(outline)\n",
-    "geo_filename = \"gulkana.geo\"\n",
-    "with open(geo_filename, \"w\") as geo_file:\n",
-    "    geo_file.write(geometry.get_code())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "41ff5cc5-97f7-4206-87e7-3e69da5a9fe0",
-   "metadata": {},
-   "source": [
-    "Next we'll call the mesh generator at the command line."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9acfe6d5-92a6-42dc-b37f-f92f9da4a936",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!gmsh -2 -v 0 gulkana.geo gulkana.msh"
+    "geometry = icepack.meshing.collection_to_gmsh(outline)\n",
+    "msh_filename = \"gulkana.msh\"\n",
+    "geometry.write(msh_filename)"
    ]
   },
   {
@@ -233,7 +214,7 @@
     "fig, axes = plt.subplots()\n",
     "axes.set_aspect(\"equal\")\n",
     "firedrake.triplot(mesh, axes=axes, interior_kw={\"linewidth\": 0.25})\n",
-    "axes.legend();"
+    "axes.legend(loc=\"upper right\");"
    ]
   },
   {
@@ -267,7 +248,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,16 @@ dependencies = [
     "shapely",
     "pooch",
     "gmsh",
-    "pygmsh<=6.1.1",
-    "meshio@git+https://github.com/icepack/meshio.git@v4.4.7",
     "MeshPy",
     "tqdm",
     "roltrilinos@git+https://github.com/icepack/Trilinos",
     "ROL@git+https://github.com/icepack/pyrol",
+]
+
+[project.optional-dependencies]
+pygmsh = [
+    "pygmsh<=6.1.1",
+    "meshio@git+https://github.com/icepack/meshio.git@v4.4.7",
 ]
 
 [build-system]


### PR DESCRIPTION
Resolves #82, deprecates `icepack.meshing.collection_to_geo`, and makes dependency on pygmsh optional. Pygmsh appears to no longer be maintained.