### PR TITLE
Geometric dimension fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,12 @@ jobs:
           jupyter nbconvert --to notebook --execute notebooks/how-to/03-adaptivity.ipynb
 
   test:
+    strategy:
+      matrix:
+        version: [2025.10.2, 2026.4.0]
     runs-on: ubuntu-latest
     container:
-      image: docker.io/firedrakeproject/firedrake-vanilla-default:2025.10.2
+      image: docker.io/firedrakeproject/firedrake-vanilla-default:${{ matrix.version }}
       options: --user root
     steps:
       - name: Install dependences

--- a/src/icepack/__init__.py
+++ b/src/icepack/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2023 by Daniel Shapero <shapero@uw.edu>
+# Copyright (C) 2017-2026 by Daniel Shapero <shapero@uw.edu>
 #
 # This file is part of icepack.
 #
@@ -12,7 +12,8 @@
 
 from icepack.norms import norm
 from icepack.interpolate import interpolate
-from icepack.utilities import depth_average, lift3d, compute_surface, vertical_velocity
+from icepack.utilities import compute_surface
+from icepack.calculus import vertical_velocity, depth_average, lift3d
 from icepack.models.viscosity import rate_factor
 import icepack.meshing
 import icepack.datasets

--- a/src/icepack/calculus.py
+++ b/src/icepack/calculus.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 by Daniel Shapero <shapero@uw.edu> and Benjamin Hills
+# Copyright (C) 2020-2026 by Daniel Shapero <shapero@uw.edu> and Benjamin Hills
 # <benjaminhhills@gmail.com>
 #
 # This file is part of icepack.
@@ -18,14 +18,17 @@ of a field in a way that does what you mean whether the underlying geometry is a
 view, flowband, or 3D model.
 """
 
+from operator import itemgetter
+import sympy
 import ufl
 import firedrake
+from .utilities import geometric_dimension
 
 
 def get_mesh_axes(mesh):
     r"""Get a string representing the axes present in the mesh -- 'x', 'xy', 'xz', or
     'xyz'"""
-    mesh_dim = mesh.geometric_dimension()
+    mesh_dim = geometric_dimension(mesh)
     extruded = mesh.layers is not None
     if mesh_dim == 1:
         return "x"
@@ -93,3 +96,165 @@ def Identity(dim):
     if dim == 1:
         return firedrake.Constant(1.0)
     return firedrake.Identity(dim)
+
+
+def depth_average(q_xz, weight=firedrake.Constant(1)):
+    r"""Return the weighted depth average of a function on an extruded mesh"""
+    element_xz = q_xz.ufl_element()
+
+    # Create the element `E x DG0` where `E` is the horizontal element for the
+    # input field. NOTE: UFL changed getting sub-elements from a function to a
+    # property so we have some try/except hackery to make this work for old and
+    # new versions.
+    element_z = firedrake.FiniteElement(family="R", cell="interval", degree=0)
+    shape = q_xz.ufl_shape
+    if len(shape) == 0:
+        try:
+            element_x = element_xz.sub_elements()[0]
+        except TypeError:
+            if hasattr(element_xz, "factor_elements"):
+                element_x = element_xz.factor_elements[0]
+            else:
+                element_x = element_xz.sub_elements[0]
+        element_avg = firedrake.TensorProductElement(element_x, element_z)
+    elif len(shape) == 1:
+        try:
+            element_xy = element_xz.sub_elements()[0].sub_elements()[0]
+        except TypeError:
+            # This has become more complicated since we may have multiple types of elements
+            # And at each stage these elements use different names for sub elements
+            if hasattr(element_xz, "factor_elements"):
+                element_hor = element_xz.factor_elements[0]
+            else:
+                element_hor = element_xz.sub_elements[0]
+            if hasattr(element_hor, "factor_elements"):
+                element_xy = element_hor.factor_elements[0]
+            else:
+                element_xy = element_hor.sub_elements[0]
+        element_u = firedrake.TensorProductElement(element_xy, element_z)
+        element_avg = firedrake.VectorElement(element_u, dim=shape[0])
+        element_x = firedrake.VectorElement(element_xy, dim=shape[0])
+    else:
+        raise NotImplementedError("Depth average of tensor fields not yet implemented!")
+
+    # Project the weighted 3D field onto vertical DG0
+    mesh_xz = q_xz.function_space().mesh()
+    Q_avg = firedrake.FunctionSpace(mesh_xz, element_avg)
+    q_avg = firedrake.project(weight * q_xz, Q_avg)
+
+    # Create a function space on the 2D mesh and a 2D function defined on this
+    # space, then copy the raw vector of expansion coefficients from the 3D DG0
+    # field into the coefficients of the 2D field.
+    mesh_x = mesh_xz._base_mesh
+    Q_x = firedrake.FunctionSpace(mesh_x, element_x)
+    q_x = firedrake.Function(Q_x)
+    q_x.dat.data[:] = q_avg.dat.data_ro[:]
+
+    return q_x
+
+
+def lift3d(q2d, Q3D):
+    r"""Return a 3D function that extends the given 2D function as a constant
+    in the vertical
+
+    This is the reverse operation of depth averaging -- it takes a 2D function
+    `q2d` and returns a function `q3d` defined over a 3D function space such
+    `q3d(x, y, z) == q2d(x, y)` for any `x, y`. The space `Q3D` of the result
+    must have the same horizontal element as the input function and a vertical
+    degree of 0.
+
+    Parameters
+    ----------
+    q2d : firedrake.Function
+        A function defined on a 2D footprint mesh
+    Q3D : firedrake.Function
+        A function space defined on a 3D mesh extruded from the footprint mesh;
+        the function space must only go up to degree 0 in the vertical.
+
+    Returns
+    -------
+    q3d : firedrake.Function
+        The 3D-lifted input field
+    """
+    q3d = firedrake.Function(Q3D)
+    assert q3d.dat.data_ro.shape == q2d.dat.data_ro.shape
+    q3d.dat.data[:] = q2d.dat.data_ro[:]
+    return q3d
+
+
+def legendre(n, ζ):
+    return sympy.functions.special.polynomials.legendre(n, 2 * ζ - 1)
+
+
+def vertically_integrate(q, h):
+    r"""
+    q : firedrake.Function
+        integrand
+    h : firedrake.Function
+        ice thickness
+    """
+
+    def weight(n, ζ):
+        norm = (1 / sympy.integrate(legendre(n, ζ) ** 2, (ζ, 0, 1))) ** 0.5
+        return sympy.lambdify(ζ, norm * legendre(n, ζ), "numpy")
+
+    def coefficient(n, q, ζ, ζsym, Q):
+        a_n = depth_average(q, weight=weight(n, ζsym)(ζ))
+        a_n3d = lift3d(a_n, Q)
+        return a_n3d
+
+    def recurrence_relation(n, ζ):
+        if n > 0:
+            return sympy.lambdify(
+                ζ,
+                (1 / (2 * (2 * n + 1))) * (legendre(n + 1, ζ) - legendre(n - 1, ζ)),
+                "numpy",
+            )
+        elif n == 0:
+            return sympy.lambdify(ζ, ζ, "numpy")
+        if n < 0:
+            raise ValueError("n must be positive")
+
+    Q = h.function_space()
+    mesh = Q.mesh()
+    ζ = firedrake.SpatialCoordinate(mesh)[geometric_dimension(mesh) - 1]
+    xdegree_q, zdegree_q = q.ufl_element().degree()
+
+    ζsym = sympy.symbols("ζsym", real=True, positive=True)
+
+    q_int = sum(
+        [
+            coefficient(k, q, ζ, ζsym, Q) * recurrence_relation(k, ζsym)(ζ)
+            for k in range(zdegree_q)
+        ]
+    )
+    return q_int
+
+
+def vertical_velocity(**kwargs):
+    r"""Compute the vertical component of the full 3D ice velocity from the
+    horizontal components, assuming that the 3D flow field is divergence-free
+
+    Note that the returned vertical velocity is in terrain-following
+    coordinates -- it records the relative depth through the ice column and
+    thus has units of inverse years.
+
+    Parameters
+    ----------
+    velocity : firedrake.Function
+    thickness : firedrake.Function
+    basal_mass_balance : firedrake.Function
+
+    Returns
+    -------
+    vertical_velocity : firedrake.Function
+    """
+    u, h, m = itemgetter("velocity", "thickness", "basal_mass_balance")(kwargs)
+
+    Q = h.function_space()
+    mesh = Q.mesh()
+    xdegree_u, zdegree_u = u.ufl_element().degree()
+    W = firedrake.FunctionSpace(mesh, "CG", xdegree_u, vfamily="GL", vdegree=zdegree_u)
+    u_div = firedrake.Function(W).interpolate(div(u))
+    return m / h - vertically_integrate(u_div, h)
+

--- a/src/icepack/models/hybrid.py
+++ b/src/icepack/models/hybrid.py
@@ -30,8 +30,10 @@ from icepack.constants import (
     gravity as g,
     strain_rate_min,
 )
-from icepack.utilities import add_kwarg_wrapper, legendre
-from icepack.calculus import grad, sym_grad, trace, Identity, FacetNormal, get_mesh_axes
+from icepack.utilities import add_kwarg_wrapper, geometric_dimension
+from icepack.calculus import (
+    grad, sym_grad, trace, Identity, FacetNormal, legendre, get_mesh_axes
+)
 
 
 def gravity(**kwargs):
@@ -97,7 +99,7 @@ def terminus(**kwargs):
     mesh = u.function_space().mesh()
     zdegree = u.ufl_element().degree()[1]
 
-    ζ = firedrake.SpatialCoordinate(mesh)[mesh.geometric_dimension() - 1]
+    ζ = firedrake.SpatialCoordinate(mesh)[geometric_dimension(mesh) - 1]
 
     b = s - h
     ζ_sl = firedrake.max_value(-b, 0) / h
@@ -121,7 +123,7 @@ def stresses(**kwargs):
     n = kwargs.get("flow_law_exponent", glen_flow_law)
 
     μ = 0.5 * A ** (-1 / n) * ε_e ** (1 / n - 1)
-    d = ufl.domain.extract_unique_domain(ε_x).geometric_dimension() - 1
+    d = geometric_dimension(ufl.domain.extract_unique_domain(ε_x)) - 1
     I = Identity(d)
     return 2 * μ * (ε_x + trace(ε_x) * I), 2 * μ * ε_z
 
@@ -131,7 +133,7 @@ def horizontal_strain_rate(**kwargs):
     following coordinates"""
     u, h, s = itemgetter("velocity", "surface", "thickness")(kwargs)
     mesh = u.function_space().mesh()
-    dim = mesh.geometric_dimension()
+    dim = geometric_dimension(mesh)
     ζ = firedrake.SpatialCoordinate(mesh)[dim - 1]
     b = s - h
     v = -((1 - ζ) * grad(b) + ζ * grad(s)) / h
@@ -144,7 +146,7 @@ def vertical_strain_rate(**kwargs):
     following coordinates"""
     u, h = itemgetter("velocity", "thickness")(kwargs)
     mesh = u.function_space().mesh()
-    du_dζ = u.dx(mesh.geometric_dimension() - 1)
+    du_dζ = u.dx(geometric_dimension(mesh) - 1)
     return 0.5 * du_dζ / h
 
 

--- a/src/icepack/models/viscosity.py
+++ b/src/icepack/models/viscosity.py
@@ -23,6 +23,7 @@ import ufl
 import firedrake
 from firedrake import sqrt, inner
 from icepack.constants import year, ideal_gas as R, glen_flow_law, strain_rate_min
+from icepack.utilities import geometric_dimension
 from icepack.calculus import sym_grad, trace, Identity
 
 transition_temperature = 263.15  # K
@@ -92,7 +93,7 @@ def membrane_stress(**kwargs):
     n = kwargs.get("flow_law_exponent", glen_flow_law)
     ε_e = _effective_strain_rate(ε, ε_min)
     μ = 0.5 * A ** (-1 / n) * ε_e ** (1 / n - 1)
-    d = ufl.domain.extract_unique_domain(ε).geometric_dimension()
+    d = geometric_dimension(ufl.domain.extract_unique_domain(ε))
     I = Identity(d)
     return 2 * μ * (ε + trace(ε) * I)
 

--- a/src/icepack/utilities.py
+++ b/src/icepack/utilities.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2025 by Daniel Shapero <shapero@uw.edu>
+# Copyright (C) 2017-2026 by Daniel Shapero <shapero@uw.edu>
 # Andrew Hoffman <hoffmaao@uw.edu>
 # Jessica Badgeley <badgeley@uw.edu>
 # This file is part of icepack.
@@ -16,12 +16,10 @@ horizontal gradients of 3D fields, lifting 2D fields into 3D, etc."""
 
 from operator import itemgetter
 import inspect
-import sympy
 import numpy as np
 import firedrake
 from firedrake import sqrt, tr, det
 from .constants import ice_density as ρ_I, water_density as ρ_W
-from .calculus import div
 
 
 default_solver_parameters = {
@@ -33,8 +31,13 @@ default_solver_parameters = {
 }
 
 
-def legendre(n, ζ):
-    return sympy.functions.special.polynomials.legendre(n, 2 * ζ - 1)
+def geometric_dimension(mesh):
+    r"""Compatibility function for old versions of Firedrake where
+    `.geometric_dimension` is a method and new versions where it's a property"""
+    try:
+        return mesh.geometric_dimension()
+    except:
+        return mesh.geometric_dimension
 
 
 def eigenvalues(a):
@@ -76,163 +79,6 @@ def compute_surface(**kwargs):
     return firedrake.Function(Q).interpolate(s_expr)
 
 
-def depth_average(q_xz, weight=firedrake.Constant(1)):
-    r"""Return the weighted depth average of a function on an extruded mesh"""
-    element_xz = q_xz.ufl_element()
-
-    # Create the element `E x DG0` where `E` is the horizontal element for the
-    # input field. NOTE: UFL changed getting sub-elements from a function to a
-    # property so we have some try/except hackery to make this work for old and
-    # new versions.
-    element_z = firedrake.FiniteElement(family="R", cell="interval", degree=0)
-    shape = q_xz.ufl_shape
-    if len(shape) == 0:
-        try:
-            element_x = element_xz.sub_elements()[0]
-        except TypeError:
-            if hasattr(element_xz, "factor_elements"):
-                element_x = element_xz.factor_elements[0]
-            else:
-                element_x = element_xz.sub_elements[0]
-        element_avg = firedrake.TensorProductElement(element_x, element_z)
-    elif len(shape) == 1:
-        try:
-            element_xy = element_xz.sub_elements()[0].sub_elements()[0]
-        except TypeError:
-            # This has become more complicated since we may have multiple types of elements
-            # And at each stage these elements use different names for sub elements
-            if hasattr(element_xz, "factor_elements"):
-                element_hor = element_xz.factor_elements[0]
-            else:
-                element_hor = element_xz.sub_elements[0]
-            if hasattr(element_hor, "factor_elements"):
-                element_xy = element_hor.factor_elements[0]
-            else:
-                element_xy = element_hor.sub_elements[0]
-        element_u = firedrake.TensorProductElement(element_xy, element_z)
-        element_avg = firedrake.VectorElement(element_u, dim=shape[0])
-        element_x = firedrake.VectorElement(element_xy, dim=shape[0])
-    else:
-        raise NotImplementedError("Depth average of tensor fields not yet implemented!")
-
-    # Project the weighted 3D field onto vertical DG0
-    mesh_xz = q_xz.function_space().mesh()
-    Q_avg = firedrake.FunctionSpace(mesh_xz, element_avg)
-    q_avg = firedrake.project(weight * q_xz, Q_avg)
-
-    # Create a function space on the 2D mesh and a 2D function defined on this
-    # space, then copy the raw vector of expansion coefficients from the 3D DG0
-    # field into the coefficients of the 2D field.
-    mesh_x = mesh_xz._base_mesh
-    Q_x = firedrake.FunctionSpace(mesh_x, element_x)
-    q_x = firedrake.Function(Q_x)
-    q_x.dat.data[:] = q_avg.dat.data_ro[:]
-
-    return q_x
-
-
-def lift3d(q2d, Q3D):
-    r"""Return a 3D function that extends the given 2D function as a constant
-    in the vertical
-
-    This is the reverse operation of depth averaging -- it takes a 2D function
-    `q2d` and returns a function `q3d` defined over a 3D function space such
-    `q3d(x, y, z) == q2d(x, y)` for any `x, y`. The space `Q3D` of the result
-    must have the same horizontal element as the input function and a vertical
-    degree of 0.
-
-    Parameters
-    ----------
-    q2d : firedrake.Function
-        A function defined on a 2D footprint mesh
-    Q3D : firedrake.Function
-        A function space defined on a 3D mesh extruded from the footprint mesh;
-        the function space must only go up to degree 0 in the vertical.
-
-    Returns
-    -------
-    q3d : firedrake.Function
-        The 3D-lifted input field
-    """
-    q3d = firedrake.Function(Q3D)
-    assert q3d.dat.data_ro.shape == q2d.dat.data_ro.shape
-    q3d.dat.data[:] = q2d.dat.data_ro[:]
-    return q3d
-
-
-def vertically_integrate(q, h):
-    r"""
-    q : firedrake.Function
-        integrand
-    h : firedrake.Function
-        ice thickness
-    """
-
-    def weight(n, ζ):
-        norm = (1 / sympy.integrate(legendre(n, ζ) ** 2, (ζ, 0, 1))) ** 0.5
-        return sympy.lambdify(ζ, norm * legendre(n, ζ), "numpy")
-
-    def coefficient(n, q, ζ, ζsym, Q):
-        a_n = depth_average(q, weight=weight(n, ζsym)(ζ))
-        a_n3d = lift3d(a_n, Q)
-        return a_n3d
-
-    def recurrence_relation(n, ζ):
-        if n > 0:
-            return sympy.lambdify(
-                ζ,
-                (1 / (2 * (2 * n + 1))) * (legendre(n + 1, ζ) - legendre(n - 1, ζ)),
-                "numpy",
-            )
-        elif n == 0:
-            return sympy.lambdify(ζ, ζ, "numpy")
-        if n < 0:
-            raise ValueError("n must be positive")
-
-    Q = h.function_space()
-    mesh = Q.mesh()
-    ζ = firedrake.SpatialCoordinate(mesh)[mesh.geometric_dimension() - 1]
-    xdegree_q, zdegree_q = q.ufl_element().degree()
-
-    ζsym = sympy.symbols("ζsym", real=True, positive=True)
-
-    q_int = sum(
-        [
-            coefficient(k, q, ζ, ζsym, Q) * recurrence_relation(k, ζsym)(ζ)
-            for k in range(zdegree_q)
-        ]
-    )
-    return q_int
-
-
-def vertical_velocity(**kwargs):
-    r"""Compute the vertical component of the full 3D ice velocity from the
-    horizontal components, assuming that the 3D flow field is divergence-free
-
-    Note that the returned vertical velocity is in terrain-following
-    coordinates -- it records the relative depth through the ice column and
-    thus has units of inverse years.
-
-    Parameters
-    ----------
-    velocity : firedrake.Function
-    thickness : firedrake.Function
-    basal_mass_balance : firedrake.Function
-
-    Returns
-    -------
-    vertical_velocity : firedrake.Function
-    """
-    u, h, m = itemgetter("velocity", "thickness", "basal_mass_balance")(kwargs)
-
-    Q = h.function_space()
-    mesh = Q.mesh()
-    xdegree_u, zdegree_u = u.ufl_element().degree()
-    W = firedrake.FunctionSpace(mesh, "CG", xdegree_u, vfamily="GL", vdegree=zdegree_u)
-    u_div = firedrake.Function(W).interpolate(div(u))
-    return m / h - vertically_integrate(u_div, h)
-
-
 def add_kwarg_wrapper(func):
     signature = inspect.signature(func)
     if any(
@@ -248,3 +94,27 @@ def add_kwarg_wrapper(func):
         return func(*args, **kwargs_)
 
     return wrapper
+
+
+def lift3d(*args, **kwargs):
+    raise ImportError(
+        "This function has moved. If you're getting this message, it's because "
+        "you're calling `icepack.utilities.lift3d`, but you want to be using "
+        "`icepack.lift3d` instead."
+    )
+
+
+def depth_average(*args, **kwargs):
+    raise ImportError(
+        "This function has moved. If you're getting this message, it's because "
+        "you're calling `icepack.utilities.depth_average`, but you want to be "
+        "using `icepack.depth_average` instead."
+    )
+
+
+def vertical_velocity(*args, **kwargs):
+    raise ImportError(
+        "This function has moved. If you're getting this message, it's because "
+        "you're calling `icepack.utilities.vertical_velocity`, but you want to be "
+        "using `icepack.vertical_velocity` instead."
+    )


### PR DESCRIPTION
Test on the newest Firedrake release (2026.4.0) and add a shim to get the geometric dimension of a mesh in a way that is both forward and back-compatible. This involved shuffling around a few functions from utilities.py to calculus.py. Those functions should only ever be accessed from the top-level `icepack` namespace so I don't think this will break anyone's code, and I've added error messages in case it does.